### PR TITLE
Integrare cu Facturare WooCommerce

### DIFF
--- a/woocommerce-oblio.php
+++ b/woocommerce-oblio.php
@@ -447,6 +447,8 @@ function _wp_oblio_generate_invoice($order_id, $options = array()) {
         }
     }
     
+    $data = apply_filters( 'woocommerce_oblio_invoice_data', $data, $order_id );
+    
     try {
         require_once WP_OBLIO_DIR . '/includes/OblioApi.php';
         require_once WP_OBLIO_DIR . '/includes/AccessTokenHandler.php';


### PR DESCRIPTION
Buna seara,

Ma numesc George Ciobanu si sunt dezvoltatorul pluginului : https://wordpress.org/plugins/facturare-persoana-fizica-sau-juridica/

Am pus un filtru pe datele pe care se creaza o factura ca sa pot prin pluginul meu sa adaug CUI si nr reg comertului daca acesta este.

Stiu ca pluginul functioneaza cu pluginul meu, dar in felul acesta de ori de cate ori eu o sa schimb ceva in plugin o sa ma asigur ca aceasta metoda functioneaza.

Imediat cum o sa actualizati acest mic fix, o sa fac update la pluginul meu de pe wordpress.org ca sa nu mai trebuiasca facut nimic in viitor.

Multumesc,
George.