### PR TITLE
fix: php notice prevented

### DIFF
--- a/includes/Hooks.php
+++ b/includes/Hooks.php
@@ -21,6 +21,7 @@ function _oblio_init() {
         register_rest_route('oblio/v1', '/card/confirm', [
             'methods' => 'POST',
             'callback' => '_wp_oblio_card_confirm',
+            'permission_callback' => '__return_true'
         ]);
     });
 }


### PR DESCRIPTION
Param `permission_callback` added to `register_rest_route`.
Fixează issue #3.

Zi faină,
Vlad