### PR TITLE
Adaugare butoane Emite/Sterge Aviz

### DIFF
--- a/includes/Hooks.php
+++ b/includes/Hooks.php
@@ -6,7 +6,8 @@ add_action('admin_menu', '_wp_oblio_load_plugin');
 add_action('oblio_sync_schedule', '_wp_oblio_sync');
 
 add_action('init', '_oblio_init');
-function _oblio_init() {
+function _oblio_init()
+{
     // Load plugin textdomain.
     load_plugin_textdomain('woocommerce-oblio', false, WP_OBLIO_DIR . '/languages');
 
@@ -27,7 +28,8 @@ function _oblio_init() {
     });
 }
 
-function _wp_oblio_payment_complete($order_id) {
+function _wp_oblio_payment_complete($order_id)
+{
     _wp_oblio_load_plugin();
     $oblio_invoice_autogen = (int) get_option('oblio_invoice_autogen');
     $oblio_invoice_autogen_use_stock = (int) get_option('oblio_invoice_autogen_use_stock');
@@ -36,11 +38,13 @@ function _wp_oblio_payment_complete($order_id) {
     }
 }
 
-function _wp_oblio_get_hash() {
+function _wp_oblio_get_hash()
+{
     return sha1(get_option('oblio_email'));
 }
 
-function _wp_oblio_card_confirm(WP_REST_Request $request) {
+function _wp_oblio_card_confirm(WP_REST_Request $request)
+{
     $hash = _wp_oblio_get_hash();
     $code = 400;
     $body = 'Bad request';
@@ -84,24 +88,25 @@ function _wp_oblio_card_confirm(WP_REST_Request $request) {
     exit($body);
 }
 
-function _wp_oblio_ajax_handler() {
+function _wp_oblio_ajax_handler()
+{
     $type       = isset($_POST['type']) ? $_POST['type'] : '';
     $cui        = isset($_POST['cui']) ? $_POST['cui'] : '';
     $name       = isset($_POST['name']) ? $_POST['name'] : '';
     $result     = array();
-    
+
     $email       = get_option('oblio_email');
     $secret      = get_option('oblio_api_secret');
-    
+
     if (!$email || !$secret) {
         die('[]');
     }
-    
+
     try {
         $accessTokenHandler = new OblioSoftware\Api\AccessTokenHandler();
         $api = new OblioSoftware\Api($email, $secret, $accessTokenHandler);
         $api->setCif($cui);
-        
+
         switch ($type) {
             case 'series_name':
             case 'series_name_proforma':
@@ -116,6 +121,7 @@ function _wp_oblio_ajax_handler() {
                 $response = $api->nomenclature('series', '', $options);
                 $result = $response['data'];
                 break;
+
             case 'workstation':
             case 'management':
                 $response = $api->nomenclature('management', '');
@@ -128,8 +134,12 @@ function _wp_oblio_ajax_handler() {
                     $workStations[$item['workStation']] = ['name' => $item['workStation']];
                 }
                 switch ($type) {
-                    case 'workstation': $result = $workStations; break;
-                    case 'management': $result = $management; break;
+                    case 'workstation':
+                        $result = $workStations;
+                        break;
+                    case 'management':
+                        $result = $management;
+                        break;
                 }
                 break;
         }
@@ -139,7 +149,8 @@ function _wp_oblio_ajax_handler() {
     die(json_encode($result));
 }
 
-function _wp_oblio_invoice_ajax_handler() {
+function _wp_oblio_invoice_ajax_handler()
+{
     header('Content-Type: application/json');
 
     $result = array();
@@ -147,31 +158,78 @@ function _wp_oblio_invoice_ajax_handler() {
 
     $order_id = $_GET['id'] ?? 0;
 
+    $issuerName = isset($_GET['issuerName']) ? sanitize_text_field(wp_unslash($_GET['issuerName'])) : '';
+    $issuerId = isset($_GET['issuerId']) ? sanitize_text_field(wp_unslash($_GET['issuerId'])) : '';
+    $deputyName = isset($_GET['deputyName']) ? sanitize_text_field(wp_unslash($_GET['deputyName'])) : '';
+    $deputyIdentityCard = isset($_GET['deputyIdentityCard']) ? sanitize_text_field(wp_unslash($_GET['deputyIdentityCard'])) : '';
+    $deputyAuto = isset($_GET['deputyAuto']) ? sanitize_text_field(wp_unslash($_GET['deputyAuto'])) : '';
+
+    $override = [
+        'issuerName'         => $issuerName,
+        'issuerId'           => $issuerId,
+        'deputyName'         => $deputyName,
+        'deputyIdentityCard' => $deputyIdentityCard,
+        'deputyAuto'         => $deputyAuto,
+    ];
+
+    if (class_exists('Oblio_Autocomplete')) {
+        Oblio_Autocomplete::save_values_from_form(array(
+            'issuerName'         => $issuerName,
+            'issuerId'           => $issuerId,
+            'deputyName'         => $deputyName,
+            'deputyIdentityCard' => $deputyIdentityCard,
+            'deputyAuto'         => $deputyAuto,
+        ));
+    }
+
     switch ($_GET['a']) {
-        case 'oblio-generate-invoice': $result = _wp_oblio_generate_invoice($order_id, ['date' => $date]); break; 
-        case 'oblio-generate-invoice-stock': $result = _wp_oblio_generate_invoice($order_id, ['use_stock' => true, 'date' => $date]); break;
-        case 'oblio-generate-proforma-stock': $result = _wp_oblio_generate_invoice($order_id, ['docType' => 'proforma', 'date' => $date]); break;
-        case 'oblio-generate-notice': $result = _wp_oblio_generate_invoice($order_id, ['docType' => 'notice', 'use_stock' => false, 'date' => $date]); break;
-        case 'oblio-generate-notice-stock': $result = _wp_oblio_generate_invoice($order_id, ['docType' => 'notice', 'use_stock' => true, 'date' => $date]); break;
-        case 'oblio-view-invoice': die(_wp_oblio_generate_invoice($order_id, ['redirect' => true, 'date' => $date])); break; 
-        case 'oblio-view-proforma': die(_wp_oblio_generate_invoice($order_id, ['redirect' => true, 'docType' => 'proforma', 'date' => $date])); break; 
-        case 'oblio-view-notice': die(_wp_oblio_generate_invoice($order_id, ['redirect' => true, 'docType' => 'notice', 'date' => $date])); break; 
-        case 'oblio-delete-invoice': $result = _wp_oblio_delete_invoice($order_id); break;
-        case 'oblio-delete-proforma': $result = _wp_oblio_delete_invoice($order_id, ['docType' => 'proforma']); break;
-        case 'oblio-delete-notice': $result = _wp_oblio_delete_invoice($order_id, ['docType' => 'notice']); break;
+        case 'oblio-generate-invoice':
+            $result = _wp_oblio_generate_invoice($order_id, array_merge(['date' => $date], $override));
+            break;
+        case 'oblio-generate-invoice-stock':
+            $result = _wp_oblio_generate_invoice($order_id, array_merge(['use_stock' => true, 'date' => $date], $override));
+            break;
+        case 'oblio-generate-proforma-stock':
+            $result = _wp_oblio_generate_invoice($order_id, array_merge(['docType' => 'proforma', 'date' => $date], $override));
+            break;
+        case 'oblio-generate-notice':
+            $result = _wp_oblio_generate_invoice($order_id, array_merge(['docType' => 'notice', 'use_stock' => false, 'date' => $date], $override));
+            break;
+        case 'oblio-generate-notice-stock':
+            $result = _wp_oblio_generate_invoice($order_id, array_merge(['docType' => 'notice', 'use_stock' => true, 'date' => $date], $override));
+            break;
+        case 'oblio-view-invoice':
+            die(_wp_oblio_generate_invoice($order_id, array_merge(['redirect' => true, 'date' => $date], $override)));
+            break;
+        case 'oblio-view-proforma':
+            die(_wp_oblio_generate_invoice($order_id, array_merge(['redirect' => true, 'docType' => 'proforma', 'date' => $date], $override)));
+            break;
+        case 'oblio-view-notice':
+            die(_wp_oblio_generate_invoice($order_id, array_merge(['redirect' => true, 'docType' => 'notice', 'date' => $date], $override)));
+            break;
+        case 'oblio-delete-invoice':
+            $result = _wp_oblio_delete_invoice($order_id);
+            break;
+        case 'oblio-delete-proforma':
+            $result = _wp_oblio_delete_invoice($order_id, ['docType' => 'proforma']);
+            break;
+        case 'oblio-delete-notice':
+            $result = _wp_oblio_delete_invoice($order_id, ['docType' => 'notice']);
+            break;
     }
     die(json_encode($result));
 }
 
 // add custom field
-function _oblio_cfwc_create() {
+function _oblio_cfwc_create()
+{
     $args = array(
         'id'            => 'custom_package_number',
         'label'         => __('Bucati pe pachet', 'woocommerce-oblio'),
         'class'         => 'cfwc-custom-field',
     );
     woocommerce_wp_text_input($args);
-    
+
     $args = array(
         'id'            => 'custom_product_type',
         'label'         => __('Tip produse', 'woocommerce-oblio'),
@@ -182,20 +240,22 @@ function _oblio_cfwc_create() {
 }
 add_action('woocommerce_product_options_general_product_data', '_oblio_cfwc_create');
 
-function _oblio_cfwc_save($post_id) {
+function _oblio_cfwc_save($post_id)
+{
     $product    = wc_get_product($post_id);
     $title      = isset($_POST['custom_package_number']) ? $_POST['custom_package_number'] : '';
     $product->update_meta_data('custom_package_number', sanitize_text_field($title));
-    
+
     $title      = isset($_POST['custom_product_type']) ? $_POST['custom_product_type'] : '';
     $product->update_meta_data('custom_product_type', sanitize_text_field($title));
-    
+
     $product->save();
 }
 add_action('woocommerce_process_product_meta', '_oblio_cfwc_save');
-    
+
 // add custom field variations
-function _oblio_cfwc_create_variations($loop, $variation_data, $variation) {
+function _oblio_cfwc_create_variations($loop, $variation_data, $variation)
+{
     $args = array(
         'id'            => 'cfwc_package_number[' . $loop . ']',
         'class'         => 'short',
@@ -207,7 +267,8 @@ function _oblio_cfwc_create_variations($loop, $variation_data, $variation) {
 }
 add_action('woocommerce_variation_options_pricing', '_oblio_cfwc_create_variations', 100, 3);
 
-function _oblio_cfwc_save_variations($variation_id, $i) {
+function _oblio_cfwc_save_variations($variation_id, $i)
+{
     $cfwc_package_number = isset($_POST['cfwc_package_number'][$i]) ? $_POST['cfwc_package_number'][$i] : '';
     update_post_meta($variation_id, 'cfwc_package_number', esc_attr($cfwc_package_number));
 }
@@ -215,17 +276,19 @@ add_action('woocommerce_save_product_variation', '_oblio_cfwc_save_variations', 
 
 register_deactivation_hook(WP_OBLIO_FILE, '_wp_oblio_clear');
 
-function _wp_oblio_clear() {
+function _wp_oblio_clear()
+{
     wp_clear_scheduled_hook('oblio_sync_schedule');
 }
 
-function _wp_oblio_load_plugin() {
+function _wp_oblio_load_plugin()
+{
     if (!class_exists('WooCommerce')) {
         return;
     }
-    
+
     // create new top-level menu
-    add_menu_page('Oblio', 'Oblio', 'manage_options', 'oblio-plugin', null, plugins_url('/assets/images/icon.png', WP_OBLIO_FILE) );
+    add_menu_page('Oblio', 'Oblio', 'manage_options', 'oblio-plugin', null, plugins_url('/assets/images/icon.png', WP_OBLIO_FILE));
     add_submenu_page('oblio-plugin', __('Conectare', 'woocommerce-oblio'), __('Conectare', 'woocommerce-oblio'), 'manage_options', 'oblio-plugin', '_wp_oblio_login_page');
     add_submenu_page('oblio-plugin', __('Setari Oblio', 'woocommerce-oblio'), __('Setari', 'woocommerce-oblio'), 'manage_options', 'oblio-settings', '_wp_oblio_settings_page');
     add_submenu_page('oblio-plugin', __('Sincronizare Manuala', 'woocommerce-oblio'), __('Sincronizare Manuala', 'woocommerce-oblio'), 'manage_options', 'oblio-import', '_wp_oblio_import_page');
@@ -233,23 +296,25 @@ function _wp_oblio_load_plugin() {
 
     // call register settings function
     add_action('admin_init', '_wp_register_oblio_plugin_settings');
-    
+
     $email   = get_option('oblio_email');
     $secret  = get_option('oblio_api_secret');
-    
+
     if (!$email || !$secret) {
         return;
     }
-    
+
     add_filter('manage_woocommerce_page_wc-orders_columns', '_wp_oblio_add_invoice_column', 10); // WC 7.1+
     add_filter('manage_edit-shop_order_columns', '_wp_oblio_add_invoice_column', 10);
     add_action('manage_woocommerce_page_wc-orders_custom_column', '_wp_oblio_add_invoice_column_content', 10, 2); // WC 7.1+
     add_action('manage_shop_order_posts_custom_column', '_wp_oblio_add_invoice_column_content', 10, 2);
-    
+
     add_action('add_meta_boxes', '_wp_oblio_order_details_box');
 
     add_action('update_option', '_wp_oblio_update_options', 10, 3);
-    
+
+    add_action('admin_enqueue_scripts', '_wp_oblio_admin_scripts');
+
     // cron sync
     $oblio_stock_sync = get_option('oblio_stock_sync');
     if ($oblio_stock_sync == '1') {
@@ -261,7 +326,8 @@ function _wp_oblio_load_plugin() {
     }
 }
 
-function _wp_oblio_update_options($option_name, $old_value, $value) {
+function _wp_oblio_update_options($option_name, $old_value, $value)
+{
     if ($option_name === 'oblio_webhook_card_complete') {
         $email       = get_option('oblio_email');
         $secret      = get_option('oblio_api_secret');
@@ -293,12 +359,14 @@ function _wp_oblio_update_options($option_name, $old_value, $value) {
                     ])
                 );
             }
-        } catch (Exception $e) {}
+        } catch (Exception $e) {
+        }
     }
 }
 
 add_action('woocommerce_thankyou', '_wp_oblio_new_order', 1000);
-function _wp_oblio_new_order($order_id) {
+function _wp_oblio_new_order($order_id)
+{
     $order = new OblioSoftware\Order($order_id);
     $series_name  = $order->get_data_info('oblio_invoice_series_name');
     $number       = $order->get_data_info('oblio_invoice_number');
@@ -306,7 +374,7 @@ function _wp_oblio_new_order($order_id) {
     if ($series_name || $number || $link) {
         return;
     }
-    
+
     $oblio_proforma_autogen = get_option('oblio_proforma_autogen');
     if ($oblio_proforma_autogen == '1') {
         _wp_oblio_generate_invoice($order_id, ['docType' => 'proforma']);
@@ -317,7 +385,8 @@ function _wp_oblio_new_order($order_id) {
 add_filter('bulk_actions-edit-shop_order', 'register_oblio_bulk_actions', 10);
 add_filter('bulk_actions-woocommerce_page_wc-orders', 'register_oblio_bulk_actions', 10); // WC 7.1+
 
-function register_oblio_bulk_actions($bulk_actions) {
+function register_oblio_bulk_actions($bulk_actions)
+{
     $bulk_actions['oblio_bulk_action'] = __('Genereaza factura in Oblio', 'woocommerce-oblio');
     return $bulk_actions;
 }
@@ -325,7 +394,8 @@ function register_oblio_bulk_actions($bulk_actions) {
 add_filter('handle_bulk_actions-edit-shop_order', 'oblio_bulk_action_handler', 10, 3);
 add_filter('handle_bulk_actions-woocommerce_page_wc-orders', 'oblio_bulk_action_handler', 10, 3); // WC 7.1+
 
-function oblio_bulk_action_handler($redirect_to, $doaction, $post_ids) {
+function oblio_bulk_action_handler($redirect_to, $doaction, $post_ids)
+{
     if ($doaction !== 'oblio_bulk_action') {
         return $redirect_to;
     }
@@ -342,7 +412,8 @@ function oblio_bulk_action_handler($redirect_to, $doaction, $post_ids) {
     return $redirect_to;
 }
 
-function _wp_register_oblio_plugin_settings() {
+function _wp_register_oblio_plugin_settings()
+{
     // register our settings
     register_setting('oblio-plugin-login-group', 'oblio_email');
     register_setting('oblio-plugin-login-group', 'oblio_api_secret');
@@ -386,7 +457,8 @@ function _wp_register_oblio_plugin_settings() {
     register_setting('oblio-plugin-settings-group', 'oblio_update_price');
 }
 
-function _wp_oblio_status_complete($order_id, $old_status, $new_status) {
+function _wp_oblio_status_complete($order_id, $old_status, $new_status)
+{
     if (!$order_id) {
         return;
     }
@@ -399,12 +471,14 @@ function _wp_oblio_status_complete($order_id, $old_status, $new_status) {
     }
 }
 
-function _wp_oblio_add_invoice_column($columns) {
+function _wp_oblio_add_invoice_column($columns)
+{
     $columns['oblio_invoice'] = 'Oblio';
     return $columns;
 }
 
-function _wp_oblio_add_invoice_column_content($column, $item = null) {
+function _wp_oblio_add_invoice_column_content($column, $item = null)
+{
     switch ($column) {
         case 'oblio_invoice':
             $order       = new OblioSoftware\Order(is_int($item) ? $item : $item->get_id());
@@ -423,19 +497,21 @@ function _wp_oblio_add_invoice_column_content($column, $item = null) {
  * Pages
  */
 
-function _wp_oblio_login_page() {
+function _wp_oblio_login_page()
+{
     if (function_exists('flush_rewrite_rules')) {
         flush_rewrite_rules();
     }
     include WP_OBLIO_DIR . '/view/login_page.php';
 }
 
-function _wp_oblio_import_page() {
+function _wp_oblio_import_page()
+{
     $email       = get_option('oblio_email');
     $secret      = get_option('oblio_api_secret');
-    
+
     if (!$email || !$secret) {
-        echo '<h1>'.__('Introdu Email si API Secret in sectiunea "Oblio"', 'woocommerce-oblio').'</h1>';
+        echo '<h1>' . __('Introdu Email si API Secret in sectiunea "Oblio"', 'woocommerce-oblio') . '</h1>';
         return;
     }
     $message = '';
@@ -450,7 +526,8 @@ function _wp_oblio_import_page() {
     include WP_OBLIO_DIR . '/view/import_page.php';
 }
 
-function _wp_oblio_settings_page() {
+function _wp_oblio_settings_page()
+{
     $email       = get_option('oblio_email');
     $secret      = get_option('oblio_api_secret');
     $cui         = get_option('oblio_cui');
@@ -458,16 +535,16 @@ function _wp_oblio_settings_page() {
     $workstation = get_option('oblio_workstation');
     $error = '';
     $fields = [];
-    
+
     if (!$email || !$secret) {
-        echo '<h1>'.__('Introdu Email si API Secret in sectiunea "Oblio"', 'woocommerce-oblio').'</h1>';
+        echo '<h1>' . __('Introdu Email si API Secret in sectiunea "Oblio"', 'woocommerce-oblio') . '</h1>';
         return;
     }
     if (!$error) {
         try {
             $accessTokenHandler = new OblioSoftware\Api\AccessTokenHandler();
             $api = new OblioSoftware\Api($email, $secret, $accessTokenHandler);
-            
+
             // get companies
             $companies = $api->nomenclature('companies');
             $series = [];
@@ -475,7 +552,7 @@ function _wp_oblio_settings_page() {
             $series_notice = [];
             $workStations = [];
             $management = [];
-            
+
             if ((int) $companies['status'] === 200 && count($companies['data']) > 0) {
                 $fields = array(
                     array(
@@ -493,7 +570,7 @@ function _wp_oblio_settings_page() {
                         'required' => true
                     ),
                 );
-                
+
                 if ($cui) {
                     $api->setCif($cui);
                     $useStock = false;
@@ -504,12 +581,12 @@ function _wp_oblio_settings_page() {
                         }
                     }
                     update_option('oblio_use_stock', (int) $useStock);
-                    
+
                     // series
                     usleep(500000); // 0.5s sleep
                     $response = $api->nomenclature('series', '', ['type' => 'Factura']);
                     $series = $response['data'];
-                    
+
                     // series proformas
                     usleep(500000); // 0.5s sleep
                     $response = $api->nomenclature('series', '', ['type' => 'Proforma']);
@@ -519,7 +596,7 @@ function _wp_oblio_settings_page() {
                     usleep(500000); // 0.5s sleep
                     $response = $api->nomenclature('series', '', ['type' => 'Aviz']);
                     $series_notice = $response['data'];
-                    
+
                     // management
                     if ($useStock) {
                         usleep(500000); // 0.5s sleep
@@ -532,7 +609,7 @@ function _wp_oblio_settings_page() {
                         }
                     }
                 }
-                
+
                 $fields[] = array(
                     'type' => 'select',
                     'label' => __('Serie factura', 'woocommerce-oblio'),
@@ -604,11 +681,11 @@ function _wp_oblio_settings_page() {
             $accessTokenHandler->clear();
         }
     }
-    
-    $showData = function($option, $data = array()) {
+
+    $showData = function ($option, $data = array()) {
         $result = '';
         if (isset($data) && is_array($data)) {
-            foreach ($data as $key=>$value) {
+            foreach ($data as $key => $value) {
                 if (isset($option[$value])) {
                     $result .= sprintf(' data-%s="%s"', $key, esc_attr($option[$value]));
                 }
@@ -619,7 +696,8 @@ function _wp_oblio_settings_page() {
     include WP_OBLIO_DIR . '/view/settings_page.php';
 }
 
-function _wp_oblio_order_details_box() {
+function _wp_oblio_order_details_box()
+{
     add_meta_box(
         'oblio_order_details_box',
         __('Facturare Oblio', 'woocommerce-oblio'),
@@ -630,12 +708,14 @@ function _wp_oblio_order_details_box() {
     );
 }
 
-function _wp_oblio_order_details_invoice_box($post) {
+function _wp_oblio_order_details_invoice_box($post)
+{
     global $wpdb;
     include WP_OBLIO_DIR . '/view/components/order_details_invoice_box.php';
 }
 
-function _wp_oblio_help() {
+function _wp_oblio_help()
+{
     header('Location: https://www.oblio.eu/integrari/woocommerce', true, 301);
     exit;
 }
@@ -646,15 +726,17 @@ function _wp_oblio_help() {
 
 add_action('init', '_wp_oblio_register_invoices_endpoint');
 
-function _wp_oblio_register_invoices_endpoint() {
-	add_rewrite_endpoint('oblio-invoices', EP_ROOT | EP_PAGES);
+function _wp_oblio_register_invoices_endpoint()
+{
+    add_rewrite_endpoint('oblio-invoices', EP_ROOT | EP_PAGES);
 }
 
 add_filter('query_vars', '_wp_oblio_invoices_query_vars');
 
-function _wp_oblio_invoices_query_vars($vars) {
-	$vars[] = 'oblio-invoices';
-	return $vars;
+function _wp_oblio_invoices_query_vars($vars)
+{
+    $vars[] = 'oblio-invoices';
+    return $vars;
 }
 
 add_filter('woocommerce_account_menu_items', '_wp_oblio_add_tab');
@@ -665,16 +747,18 @@ add_filter('woocommerce_account_menu_items', '_wp_oblio_add_tab');
  *     content: "\f570";
  *  }
  */
-function _wp_oblio_add_tab($items) {
+function _wp_oblio_add_tab($items)
+{
     $result = array_splice($items, count($items) - 1);
-	$items['oblio-invoices'] = __('Facturi', 'woocommerce-oblio');
+    $items['oblio-invoices'] = __('Facturi', 'woocommerce-oblio');
     $items = array_merge($items, $result);
-	return $items;
+    return $items;
 }
 
 add_action('woocommerce_account_oblio-invoices_endpoint', '_wp_oblio_add_content');
 
-function _wp_oblio_add_content() {
+function _wp_oblio_add_content()
+{
     global $wpdb;
 
     $auth_id = get_current_user_id();
@@ -700,4 +784,21 @@ function _wp_oblio_add_content() {
         $clientCondition;
     $invoices = $wpdb->get_results($sql);
     include WP_OBLIO_DIR . '/view/account_invoices_page.php';
-} 
+}
+
+function _wp_oblio_admin_scripts($hook_suffix)
+{
+    // Afișăm autocomplete doar în ecranul de editare comandă / lista comenzi
+    if (strpos($hook_suffix, 'shop_order') === false && strpos($hook_suffix, 'wc-orders') === false) {
+        return;
+    }
+
+    // Ne asigurăm că jQuery este încărcat
+    wp_enqueue_script('jquery');
+
+    // Pasăm datele de autocomplete către JS
+    if (class_exists('Oblio_Autocomplete')) {
+        $data = Oblio_Autocomplete::get_all_values();
+        wp_localize_script('jquery', 'oblioAutocomplete', $data);
+    }
+}

--- a/includes/Hooks.php
+++ b/includes/Hooks.php
@@ -799,6 +799,7 @@ function _wp_oblio_admin_scripts($hook_suffix)
     // Pasăm datele de autocomplete către JS
     if (class_exists('Oblio_Autocomplete')) {
         $data = Oblio_Autocomplete::get_all_values();
+        $data['lastSet'] = Oblio_Autocomplete::get_last_set();
         wp_localize_script('jquery', 'oblioAutocomplete', $data);
     }
 }

--- a/includes/Hooks.php
+++ b/includes/Hooks.php
@@ -105,9 +105,13 @@ function _wp_oblio_ajax_handler() {
         switch ($type) {
             case 'series_name':
             case 'series_name_proforma':
+            case 'series_name_notice':
                 $options = ['type' => 'Factura'];
                 if ($type == 'series_name_proforma') {
                     $options['type'] = 'Proforma';
+                }
+                if ($type == 'series_name_notice') {
+                    $options['type'] = 'Aviz';
                 }
                 $response = $api->nomenclature('series', '', $options);
                 $result = $response['data'];
@@ -147,10 +151,14 @@ function _wp_oblio_invoice_ajax_handler() {
         case 'oblio-generate-invoice': $result = _wp_oblio_generate_invoice($order_id, ['date' => $date]); break; 
         case 'oblio-generate-invoice-stock': $result = _wp_oblio_generate_invoice($order_id, ['use_stock' => true, 'date' => $date]); break;
         case 'oblio-generate-proforma-stock': $result = _wp_oblio_generate_invoice($order_id, ['docType' => 'proforma', 'date' => $date]); break;
+        case 'oblio-generate-notice': $result = _wp_oblio_generate_invoice($order_id, ['docType' => 'notice', 'use_stock' => false, 'date' => $date]); break;
+        case 'oblio-generate-notice-stock': $result = _wp_oblio_generate_invoice($order_id, ['docType' => 'notice', 'use_stock' => true, 'date' => $date]); break;
         case 'oblio-view-invoice': die(_wp_oblio_generate_invoice($order_id, ['redirect' => true, 'date' => $date])); break; 
         case 'oblio-view-proforma': die(_wp_oblio_generate_invoice($order_id, ['redirect' => true, 'docType' => 'proforma', 'date' => $date])); break; 
+        case 'oblio-view-notice': die(_wp_oblio_generate_invoice($order_id, ['redirect' => true, 'docType' => 'notice', 'date' => $date])); break; 
         case 'oblio-delete-invoice': $result = _wp_oblio_delete_invoice($order_id); break;
         case 'oblio-delete-proforma': $result = _wp_oblio_delete_invoice($order_id, ['docType' => 'proforma']); break;
+        case 'oblio-delete-notice': $result = _wp_oblio_delete_invoice($order_id, ['docType' => 'notice']); break;
     }
     die(json_encode($result));
 }
@@ -342,6 +350,7 @@ function _wp_register_oblio_plugin_settings() {
     register_setting('oblio-plugin-settings-group', 'oblio_use_stock');
     register_setting('oblio-plugin-settings-group', 'oblio_series_name');
     register_setting('oblio-plugin-settings-group', 'oblio_series_name_proforma');
+    register_setting('oblio-plugin-settings-group', 'oblio_series_name_notice');
     register_setting('oblio-plugin-settings-group', 'oblio_workstation');
     register_setting('oblio-plugin-settings-group', 'oblio_management');
     register_setting('oblio-plugin-settings-group', 'oblio_invoice_autogen');
@@ -463,6 +472,7 @@ function _wp_oblio_settings_page() {
             $companies = $api->nomenclature('companies');
             $series = [];
             $series_proforma = [];
+            $series_notice = [];
             $workStations = [];
             $management = [];
             
@@ -504,6 +514,11 @@ function _wp_oblio_settings_page() {
                     usleep(500000); // 0.5s sleep
                     $response = $api->nomenclature('series', '', ['type' => 'Proforma']);
                     $series_proforma = $response['data'];
+
+                    // series notices (avize)
+                    usleep(500000); // 0.5s sleep
+                    $response = $api->nomenclature('series', '', ['type' => 'Aviz']);
+                    $series_notice = $response['data'];
                     
                     // management
                     if ($useStock) {
@@ -537,6 +552,19 @@ function _wp_oblio_settings_page() {
                     'name' => 'oblio_series_name_proforma',
                     'options' => [
                         'query' => array_merge([['name' => 'Selecteaza']], $series_proforma),
+                        'id'    => 'name',
+                        'name'  => 'name',
+                    ],
+                    'class' => 'chosen',
+                    // 'lang' => true,
+                    'required' => true
+                );
+                $fields[] = array(
+                    'type' => 'select',
+                    'label' => __('Serie aviz', 'woocommerce-oblio'),
+                    'name' => 'oblio_series_name_notice',
+                    'options' => [
+                        'query' => array_merge([['name' => 'Selecteaza']], $series_notice),
                         'id'    => 'name',
                         'name'  => 'name',
                     ],

--- a/includes/class-oblio-autocomplete.php
+++ b/includes/class-oblio-autocomplete.php
@@ -1,0 +1,116 @@
+<?php
+
+if (!defined('ABSPATH')) {
+    exit;
+}
+
+class Oblio_Autocomplete {
+
+    /**
+     * Mapare field => key wp_option
+     * ex: 'issuerName' => 'oblio_autocomplete_issuerName'
+     *
+     * @var array<string,string>
+     */
+    public static $fields = array(
+        'issuerName'         => 'oblio_autocomplete_issuerName',
+        'issuerId'           => 'oblio_autocomplete_issuerId',
+        'deputyName'         => 'oblio_autocomplete_deputyName',
+        'deputyIdentityCard' => 'oblio_autocomplete_deputyIdentityCard',
+        'deputyAuto'         => 'oblio_autocomplete_deputyAuto',
+    );
+
+    /**
+     * Returnează lista de valori pentru un câmp.
+     *
+     * @param string $field
+     * @return array
+     */
+    public static function get_values($field) {
+        if (!isset(self::$fields[$field])) {
+            return array();
+        }
+        $option = self::$fields[$field];
+        $values = get_option($option, array());
+        if (!is_array($values)) {
+            $values = array();
+        }
+        // Normalize: string keys, unice, ordonate simplu
+        $clean = array();
+        foreach ($values as $v) {
+            $v = trim((string) $v);
+            if ($v === '') {
+                continue;
+            }
+            $clean[$v] = $v;
+        }
+        return array_values($clean);
+    }
+
+    /**
+     * Adaugă o valoare nouă pentru un câmp (unic, curățat).
+     *
+     * @param string $field
+     * @param string $value
+     * @return void
+     */
+    public static function save_value($field, $value) {
+        if (!isset(self::$fields[$field])) {
+            return;
+        }
+        $value = trim((string) $value);
+        if ($value === '') {
+            return;
+        }
+
+        $option = self::$fields[$field];
+        $values = get_option($option, array());
+        if (!is_array($values)) {
+            $values = array();
+        }
+
+        // Nu duplicăm valori (case-sensitive simplu)
+        if (in_array($value, $values, true)) {
+            return;
+        }
+
+        $values[] = $value;
+        update_option($option, $values);
+    }
+
+    /**
+     * Procesează toate câmpurile dintr-un submit de form.
+     *
+     * @param array $form_data tipic $_POST sau $_REQUEST
+     * @return void
+     */
+    public static function save_values_from_form(array $form_data) {
+        foreach (self::$fields as $field => $option) {
+            if (!isset($form_data[$field])) {
+                continue;
+            }
+            $raw = $form_data[$field];
+
+            if (is_array($raw)) {
+                foreach ($raw as $value) {
+                    self::save_value($field, sanitize_text_field(wp_unslash($value)));
+                }
+            } else {
+                self::save_value($field, sanitize_text_field(wp_unslash($raw)));
+            }
+        }
+    }
+
+    /**
+     * Returnează toate câmpurile cu valorile lor.
+     *
+     * @return array<string,array>
+     */
+    public static function get_all_values() {
+        $result = array();
+        foreach (self::$fields as $field => $option) {
+            $result[$field] = self::get_values($field);
+        }
+        return $result;
+    }
+}

--- a/includes/class-oblio-autocomplete.php
+++ b/includes/class-oblio-autocomplete.php
@@ -21,6 +21,14 @@ class Oblio_Autocomplete {
     );
 
     /**
+     * Stochează setul complet folosit la ultima emitere reușită.
+     * Array format: field => value
+     *
+     * @var string
+     */
+    public static $lastSetOptionKey = 'oblio_autocomplete_lastSet';
+
+    /**
      * Returnează lista de valori pentru un câmp.
      *
      * @param string $field
@@ -69,12 +77,13 @@ class Oblio_Autocomplete {
             $values = array();
         }
 
-        // Nu duplicăm valori (case-sensitive simplu)
-        if (in_array($value, $values, true)) {
-            return;
+        // Păstrăm unicitatea, dar actualizăm "recency":
+        // dacă valoarea există deja, o scoatem și o re-adăugăm la final.
+        $existingIndex = array_search($value, $values, true);
+        if ($existingIndex !== false) {
+            array_splice($values, $existingIndex, 1);
         }
-
-        $values[] = $value;
+        $values[] = $value; // ultima valoare = cea mai recent folosită
         update_option($option, $values);
     }
 
@@ -85,6 +94,7 @@ class Oblio_Autocomplete {
      * @return void
      */
     public static function save_values_from_form(array $form_data) {
+        $lastSet = [];
         foreach (self::$fields as $field => $option) {
             if (!isset($form_data[$field])) {
                 continue;
@@ -93,11 +103,23 @@ class Oblio_Autocomplete {
 
             if (is_array($raw)) {
                 foreach ($raw as $value) {
-                    self::save_value($field, sanitize_text_field(wp_unslash($value)));
+                    $clean = sanitize_text_field(wp_unslash($value));
+                    if (trim((string) $clean) !== '') {
+                        $lastSet[$field] = $clean; // ultima valoare ne-goală din listă
+                    }
+                    self::save_value($field, $clean);
                 }
             } else {
-                self::save_value($field, sanitize_text_field(wp_unslash($raw)));
+                $clean = sanitize_text_field(wp_unslash($raw));
+                if (trim((string) $clean) !== '') {
+                    $lastSet[$field] = $clean;
+                }
+                self::save_value($field, $clean);
             }
+        }
+
+        if (!empty($lastSet)) {
+            update_option(self::$lastSetOptionKey, $lastSet);
         }
     }
 
@@ -112,5 +134,27 @@ class Oblio_Autocomplete {
             $result[$field] = self::get_values($field);
         }
         return $result;
+    }
+
+    /**
+     * @return array<string,string> field => value
+     */
+    public static function get_last_set() {
+        $values = get_option(self::$lastSetOptionKey, []);
+        if (!is_array($values)) {
+            return [];
+        }
+        $clean = [];
+        foreach (self::$fields as $field => $optionKey) {
+            if (!isset($values[$field])) {
+                continue;
+            }
+            $v = trim((string) $values[$field]);
+            if ($v === '') {
+                continue;
+            }
+            $clean[$field] = $v;
+        }
+        return $clean;
     }
 }

--- a/view/components/order_details_invoice_box.php
+++ b/view/components/order_details_invoice_box.php
@@ -74,7 +74,7 @@ $displayDocument = function ( $post, $options = [] ) use ( $wpdb, $order ) {
 			__( 'Emite ' . $options['name'], 'woocommerce-oblio' )
 		);
 
-		if ( $options['docType'] === 'invoice' && intval( get_option( 'oblio_use_stock' ) ) === 1) {
+		if ( in_array( $options['docType'], [ 'invoice', 'notice' ], true ) && intval( get_option( 'oblio_use_stock' ) ) === 1) {
 			echo sprintf(
 				'<p><a class="button oblio-generate-%s" href="%s" target="_blank">%s</a></p>',
 				$options['docType'],
@@ -84,7 +84,7 @@ $displayDocument = function ( $post, $options = [] ) use ( $wpdb, $order ) {
 		}
 	}
 
-	if ( ! $link || $lastInvoice == $post->ID || $options['docType'] === 'proforma' ) {
+	if ( ! $link || $lastInvoice == $post->ID || in_array( $options['docType'], [ 'proforma', 'notice' ], true ) ) {
 		$hidden = $link ? '' : 'hidden';
 		echo sprintf(
 			'<p><a class="button oblio-delete-%s %s" href="%s" target="_blank">%s</a></p>',
@@ -189,6 +189,12 @@ $displayDocument( $post, [
 			] );
 		}
 	}
+] );
+
+// Shipping notice (Aviz) – emitted similarly to proforma, but with its own series and payload rules.
+$displayDocument( $post, [
+	'docType' => 'notice',
+	'name'    => 'aviz',
 ] );
 ?>
 <style type="text/css">

--- a/view/components/order_details_invoice_box.php
+++ b/view/components/order_details_invoice_box.php
@@ -146,6 +146,10 @@ $displayDocument = function ($post, $options = []) use ($wpdb, $order) {
 			$(document).ready(function() {
 				// Autocomplete local cu <datalist>, bazat pe oblioAutocomplete (wp_localize_script)
 				if (typeof window.oblioAutocomplete === 'object' && window.oblioAutocomplete !== null) {
+					var lastSet = (typeof window.oblioAutocomplete.lastSet === 'object' && window.oblioAutocomplete.lastSet !== null)
+						? window.oblioAutocomplete.lastSet
+						: {};
+
 					var map = {
 						issuerName: '#intocmit_de',
 						issuerId: '#intocmit_cnp',
@@ -182,6 +186,16 @@ $displayDocument = function ($post, $options = []) use ($wpdb, $order) {
 							}
 							$('<option></option>').attr('value', val).appendTo($datalist);
 						});
+
+						// Prefill with last used value (most recently saved).
+						// Only override if input is currently empty (avoid clobbering user edits).
+						if (($input.val() === '' || $input.val() === null) && values.length > 0) {
+							var lastValue = values[values.length - 1];
+							var prefillValue = (lastSet[field] !== undefined && lastSet[field] !== '') ? lastSet[field] : lastValue;
+							if (prefillValue) {
+								$input.val(prefillValue);
+							}
+						}
 					});
 				}
 

--- a/view/components/order_details_invoice_box.php
+++ b/view/components/order_details_invoice_box.php
@@ -1,6 +1,6 @@
-
 <div class="oblio-ajax-response"></div>
 <?php
+
 use Automattic\WooCommerce\Internal\DataStores\Orders\OrdersTableDataStore;
 
 $order = new OblioSoftware\Order($post->ID);
@@ -15,10 +15,46 @@ if ($order->get_data_info('oblio_invoice_link')) {
 	$invoiceDateClass = 'hidden';
 }
 ?>
+<div class="row g-2 oblio-issuer-deputy-fields" style="margin-bottom:10px;">
+	<div class="col-lg-6">
+		<div class="" style="position:relative;">
+			<label class="form-label" for="intocmit_de"><?php echo esc_html__('Intocmit de', 'woocommerce-oblio'); ?></label>
+			<input type="text" class="form-control form-control-sm" name="intocmit_de" id="intocmit_de" value="" autocomplete="off" />
+			<input type="hidden" name="intocmit_de_id" id="intocmit_de_id" value="" />
+			<div id="oblio_autocomplete_intocmit_de" class="oblio-autocomplete-list" style="display:none;"></div>
+		</div>
+	</div>
+	<div class="col-lg-6">
+		<div class="">
+			<label class="form-label" for="intocmit_cnp"><?php echo esc_html__('CNP', 'woocommerce-oblio'); ?></label>
+			<input type="text" class="form-control form-control-sm" name="intocmit_cnp" id="intocmit_cnp" value="" autocomplete="off" />
+		</div>
+	</div>
+	<div class="col-lg-6">
+		<div class="" style="position:relative;">
+			<label class="form-label" for="delegat"><?php echo esc_html__('Delegat', 'woocommerce-oblio'); ?></label>
+			<input type="text" class="form-control form-control-sm" name="delegat" id="delegat" value="" autocomplete="off" />
+			<input type="hidden" name="delegat_id" id="delegat_id" value="" />
+			<div id="oblio_autocomplete_delegat" class="oblio-autocomplete-list" style="display:none;"></div>
+		</div>
+	</div>
+	<div class="col-lg-6">
+		<div class="">
+			<label class="form-label" for="delegat_buletin"><?php echo esc_html__('Carte Identitate', 'woocommerce-oblio'); ?></label>
+			<input type="text" class="form-control form-control-sm" name="delegat_buletin" id="delegat_buletin" value="" autocomplete="off" />
+		</div>
+	</div>
+	<div class="col-lg-6">
+		<div class="">
+			<label class="form-label" for="delegat_auto"><?php echo esc_html__('Auto', 'woocommerce-oblio'); ?></label>
+			<input type="text" class="form-control form-control-sm" name="delegat_auto" id="delegat_auto" value="" autocomplete="off" />
+		</div>
+	</div>
+</div>
 <input type="date" id="oblio_invoice_date" class="<?php echo $invoiceDateClass; ?>" value="<?php echo $invoiceDate; ?>" />
 <?php
-$displayDocument = function ( $post, $options = [] ) use ( $wpdb, $order ) {
-	if ( empty( $options['docType'] ) ) {
+$displayDocument = function ($post, $options = []) use ($wpdb, $order) {
+	if (empty($options['docType'])) {
 		$options['docType'] = 'invoice';
 	}
 
@@ -26,15 +62,15 @@ $displayDocument = function ( $post, $options = [] ) use ( $wpdb, $order ) {
 	$number_key      = 'oblio_' . $options['docType'] . '_number';
 	$link_key        = 'oblio_' . $options['docType'] . '_link';
 
-	$series_name = $order->get_data_info( $series_name_key );
-	$number      = $order->get_data_info( $number_key );
-	$link        = $order->get_data_info( $link_key );
+	$series_name = $order->get_data_info($series_name_key);
+	$number      = $order->get_data_info($number_key);
+	$link        = $order->get_data_info($link_key);
 
-    $order_meta_table = OblioSoftware\Order::get_meta_table_name();
-    $order_id_field   = OblioSoftware\Order::get_meta_table_field_name();
-    $meta_id_field    = $order_id_field === 'post_id' ? 'meta_id' : 'id';
+	$order_meta_table = OblioSoftware\Order::get_meta_table_name();
+	$order_id_field   = OblioSoftware\Order::get_meta_table_field_name();
+	$meta_id_field    = $order_id_field === 'post_id' ? 'meta_id' : 'id';
 
-	$sql = $wpdb->prepare( "
+	$sql = $wpdb->prepare("
         SELECT {$order_id_field}  FROM (
             SELECT pmn.{$order_id_field}, pmn.meta_value
             FROM `{$order_meta_table}` pmn
@@ -47,159 +83,240 @@ $displayDocument = function ( $post, $options = [] ) use ( $wpdb, $order ) {
         ) AS tab
         ORDER BY CAST(meta_value AS UNSIGNED) DESC
         LIMIT 1
-    ", $number_key, $series_name_key, $series_name );
+    ", $number_key, $series_name_key, $series_name);
 
-	$lastInvoice = $wpdb->get_var( $sql );
+	$lastInvoice = $wpdb->get_var($sql);
 
-	if ( $link ) {
+	if ($link) {
 		echo sprintf(
 			'<p><a class="button" href="%s" target="_blank">%s</a></p>',
-			_wp_oblio_build_url( 'oblio-view-' . $options['docType'], $post ),
-			sprintf( __( 'Vezi %s %s %d', 'woocommerce-oblio' ), $options['name'], $series_name, $number )
+			_wp_oblio_build_url('oblio-view-' . $options['docType'], $post),
+			sprintf(__('Vezi %s %s %d', 'woocommerce-oblio'), $options['name'], $series_name, $number)
 		);
 
-		parse_str( parse_url( $link, PHP_URL_QUERY ), $output );
+		parse_str(parse_url($link, PHP_URL_QUERY), $output);
 		$viewLink = 'https://www.oblio.eu/docs/preview/' . $options['docType'] . '/' . $output['id'];
 
 		echo sprintf(
 			'<p><a class="button" href="%s" target="_blank">%s</a></p>',
 			$viewLink,
-			sprintf( __( 'Editeaza %s %s %d', 'woocommerce-oblio' ), $options['name'], $series_name, $number )
+			sprintf(__('Editeaza %s %s %d', 'woocommerce-oblio'), $options['name'], $series_name, $number)
 		);
 	} else {
 		echo sprintf(
 			'<p><a class="button oblio-generate-%s" href="%s" target="_blank">%s</a></p>',
 			$options['docType'],
-			_wp_oblio_build_url( 'oblio-generate-' . $options['docType'] . '-stock', $post ),
-			__( 'Emite ' . $options['name'], 'woocommerce-oblio' )
+			_wp_oblio_build_url('oblio-generate-' . $options['docType'] . '-stock', $post),
+			__('Emite ' . $options['name'], 'woocommerce-oblio')
 		);
 
-		if ( in_array( $options['docType'], [ 'invoice', 'notice' ], true ) && intval( get_option( 'oblio_use_stock' ) ) === 1) {
+		if (in_array($options['docType'], ['invoice', 'notice'], true) && intval(get_option('oblio_use_stock')) === 1) {
 			echo sprintf(
 				'<p><a class="button oblio-generate-%s" href="%s" target="_blank">%s</a></p>',
 				$options['docType'],
-				_wp_oblio_build_url( 'oblio-generate-' . $options['docType'], $post ),
-				__( 'Emite ' . $options['name'] . ' fara Descarcare', 'woocommerce-oblio' )
+				_wp_oblio_build_url('oblio-generate-' . $options['docType'], $post),
+				__('Emite ' . $options['name'] . ' fara Descarcare', 'woocommerce-oblio')
 			);
 		}
 	}
 
-	if ( ! $link || $lastInvoice == $post->ID || in_array( $options['docType'], [ 'proforma', 'notice' ], true ) ) {
+	if (! $link || $lastInvoice == $post->ID || in_array($options['docType'], ['proforma', 'notice'], true)) {
 		$hidden = $link ? '' : 'hidden';
 		echo sprintf(
 			'<p><a class="button oblio-delete-%s %s" href="%s" target="_blank">%s</a></p>',
 			$options['docType'],
 			$hidden,
-			_wp_oblio_build_url( 'oblio-delete-' . $options['docType'], $post ),
-			__( 'Sterge ' . $options['name'], 'woocommerce-oblio' )
+			_wp_oblio_build_url('oblio-delete-' . $options['docType'], $post),
+			__('Sterge ' . $options['name'], 'woocommerce-oblio')
 		);
 	}
 
-	if ( isset( $options['fn'] ) && is_callable( $options['fn'] ) ) {
-		$options['fn']( [
+	if (isset($options['fn']) && is_callable($options['fn'])) {
+		$options['fn']([
 			'series_name' => $series_name,
 			'number'      => $number,
 			'link'        => $link,
-		] );
+		]);
 	}
 
-	?>
-    <script type="text/javascript">
-        "use strict";
-        (function ($) {
-            $(document).ready(function () {
-                var buttons = $('.oblio-generate-<?php echo $options['docType']; ?>'),
-                    deleteButton = $('.oblio-delete-<?php echo $options['docType']; ?>'),
-                    responseContainer = $('#oblio_order_details_box .oblio-ajax-response');
-                buttons.on('click', function (e) {
-                    var self = $(this);
-                    if (self.hasClass('disabled')) {
-                        return false;
-                    }
-                    if (!self.hasClass('oblio-generate-<?php echo $options['docType']; ?>')) {
-                        return true;
-                    }
-                    e.preventDefault();
-                    self.addClass('disabled');
-                    jQuery.ajax({
-                        dataType: 'json',
-                        url: self.attr('href') + '&date=' + $('#oblio_invoice_date').val(),
-                        data: {},
-                        success: function (response) {
-                            var alert = '';
-                            self.removeClass('disabled');
+?>
+	<script type="text/javascript">
+		"use strict";
+		(function($) {
+			$(document).ready(function() {
+				// Autocomplete local cu <datalist>, bazat pe oblioAutocomplete (wp_localize_script)
+				if (typeof window.oblioAutocomplete === 'object' && window.oblioAutocomplete !== null) {
+					var map = {
+						issuerName: '#intocmit_de',
+						issuerId: '#intocmit_cnp',
+						deputyName: '#delegat',
+						deputyIdentityCard: '#delegat_buletin',
+						deputyAuto: '#delegat_auto'
+					};
 
-                            if ('link' in response) {
-                                buttons
-                                    .not(self)
-                                    .hide();
-                                self
-                                    .attr('href', response.link)
-                                    .removeClass('oblio-generate-<?php echo $options['docType']; ?>')
-                                    .text(`Vezi <?php echo $options['docType']; ?> ${response.seriesName} ${response.number}`);
-                                alert = '<ul class="order_notes"><li class="note system-note"><div class="note_content note_success"><?php echo strtoupper( $options['name'] ); ?> a fost emisa</div></li></ul>';
-                                deleteButton.removeClass('hidden');
+					Object.keys(map).forEach(function(field) {
+						var selector = map[field];
+						var $input = $(selector);
+						if ($input.length === 0) {
+							return;
+						}
+
+						var values = window.oblioAutocomplete[field] || [];
+						if (!Array.isArray(values) || values.length === 0) {
+							return;
+						}
+
+						var listId = 'oblio_datalist_' + field;
+						var $datalist = $('#' + listId);
+						if ($datalist.length === 0) {
+							$datalist = $('<datalist></datalist>').attr('id', listId);
+							$input.attr('list', listId);
+							$input.after($datalist);
+						} else {
+							$datalist.empty();
+						}
+
+						values.forEach(function(val) {
+							if (!val) {
+								return;
+							}
+							$('<option></option>').attr('value', val).appendTo($datalist);
+						});
+					});
+				}
+
+				var buttons = $('.oblio-generate-<?php echo $options['docType']; ?>'),
+					deleteButton = $('.oblio-delete-<?php echo $options['docType']; ?>'),
+					responseContainer = $('#oblio_order_details_box .oblio-ajax-response');
+
+				buttons.on('click', function(e) {
+					var self = $(this);
+					if (self.hasClass('disabled')) {
+						return false;
+					}
+					if (!self.hasClass('oblio-generate-<?php echo $options['docType']; ?>')) {
+						return true;
+					}
+					e.preventDefault();
+					self.addClass('disabled');
+
+					var requestUrl = self.attr('href') + '&date=' + encodeURIComponent($('#oblio_invoice_date').val());
+					<?php if (in_array($options['docType'], ['invoice', 'notice'], true)) { ?>
+						var issuerName = $.trim($('#intocmit_de').val());
+						var issuerId = $.trim($('#intocmit_cnp').val());
+						var deputyName = $.trim($('#delegat').val());
+						var deputyIdentityCard = $.trim($('#delegat_buletin').val());
+						var deputyAuto = $.trim($('#delegat_auto').val());
+
+						if (issuerName !== '') {
+							requestUrl += '&issuerName=' + encodeURIComponent(issuerName);
+						}
+						if (issuerId !== '') {
+							requestUrl += '&issuerId=' + encodeURIComponent(issuerId);
+						}
+						if (deputyName !== '') {
+							requestUrl += '&deputyName=' + encodeURIComponent(deputyName);
+						}
+						if (deputyIdentityCard !== '') {
+							requestUrl += '&deputyIdentityCard=' + encodeURIComponent(deputyIdentityCard);
+						}
+						if (deputyAuto !== '') {
+							requestUrl += '&deputyAuto=' + encodeURIComponent(deputyAuto);
+						}
+					<?php } ?>
+
+					jQuery.ajax({
+						dataType: 'json',
+						url: requestUrl,
+						data: {},
+						success: function(response) {
+							var alert = '';
+							self.removeClass('disabled');
+
+							if ('link' in response) {
+								buttons
+									.not(self)
+									.hide();
+								self
+									.attr('href', response.link)
+									.removeClass('oblio-generate-<?php echo $options['docType']; ?>')
+									.text(`Vezi <?php echo $options['docType']; ?> ${response.seriesName} ${response.number}`);
+								alert = '<ul class="order_notes"><li class="note system-note"><div class="note_content note_success"><?php echo strtoupper($options['name']); ?> a fost emisa</div></li></ul>';
+								deleteButton.removeClass('hidden');
 
 								<?php if ($options['docType'] === 'invoice') { ?>
-                                $('#oblio_invoice_date').addClass('hidden');
+									$('#oblio_invoice_date').addClass('hidden');
 								<?php } ?>
-                            } else if ('error' in response) {
-                                alert = '<ul class="order_notes"><li class="note system-note"><div class="note_content note_error">' + response.error + '</div></li></ul>';
-                            }
-                            responseContainer.html(alert);
-                        }
-                    });
-                });
-                deleteButton.on('click', function (e) {
-                    e.preventDefault();
-                    var self = $(this);
-                    if (self.hasClass('disabled')) {
-                        return false;
-                    }
-                    self.addClass('disabled');
-                    jQuery.ajax({
-                        dataType: 'json',
-                        url: self.attr('href'),
-                        data: {},
-                        success: function (response) {
-                            if (response.type == 'success') {
-                                location.reload();
-                            } else {
-                                var alert = '<ul class="order_notes"><li class="note system-note"><div class="note_content note_error">' + response.message + '</div></li></ul>';
-                                responseContainer.html(alert);
-                                self.removeClass('disabled');
-                            }
-                        }
-                    });
-                });
-            });
-        })(jQuery);
-    </script>
-	<?php
+							} else if ('error' in response) {
+								alert = '<ul class="order_notes"><li class="note system-note"><div class="note_content note_error">' + response.error + '</div></li></ul>';
+							}
+							responseContainer.html(alert);
+						}
+					});
+				});
+				deleteButton.on('click', function(e) {
+					e.preventDefault();
+					var self = $(this);
+					if (self.hasClass('disabled')) {
+						return false;
+					}
+					self.addClass('disabled');
+					jQuery.ajax({
+						dataType: 'json',
+						url: self.attr('href'),
+						data: {},
+						success: function(response) {
+							if (response.type == 'success') {
+								location.reload();
+							} else {
+								var alert = '<ul class="order_notes"><li class="note system-note"><div class="note_content note_error">' + response.message + '</div></li></ul>';
+								responseContainer.html(alert);
+								self.removeClass('disabled');
+							}
+						}
+					});
+				});
+			});
+		})(jQuery);
+	</script>
+<?php
 };
 
-$displayDocument( $post, [
+$displayDocument($post, [
 	'docType' => 'invoice',
 	'name'    => 'factura',
-	'fn'      => function ( $data ) use ( $displayDocument, $post ) {
-		if ( ! $data['link'] ) {
-			$displayDocument( $post, [
+	'fn'      => function ($data) use ($displayDocument, $post) {
+		if (! $data['link']) {
+			$displayDocument($post, [
 				'docType' => 'proforma',
 				'name'    => 'proforma',
-			] );
+			]);
 		}
 	}
-] );
+]);
 
 // Shipping notice (Aviz) – emitted similarly to proforma, but with its own series and payload rules.
-$displayDocument( $post, [
+$displayDocument($post, [
 	'docType' => 'notice',
 	'name'    => 'aviz',
-] );
+]);
 ?>
 <style type="text/css">
-ul.order_notes li.system-note .note_content.note_error {background:#c9356e;color:#fff;}
-ul.order_notes li .note_content.note_error::after {border-color: #c9356e transparent;}
-ul.order_notes li.system-note .note_content.note_success {background:#46b450;color:#fff;}
-ul.order_notes li .note_content.note_success::after {border-color: #46b450 transparent;}
+	ul.order_notes li.system-note .note_content.note_error {
+		background: #c9356e;
+		color: #fff;
+	}
+
+	ul.order_notes li .note_content.note_error::after {
+		border-color: #c9356e transparent;
+	}
+
+	ul.order_notes li.system-note .note_content.note_success {
+		background: #46b450;
+		color: #fff;
+	}
+
+	ul.order_notes li .note_content.note_success::after {
+		border-color: #46b450 transparent;
+	}
 </style>

--- a/view/settings_page.php
+++ b/view/settings_page.php
@@ -9,6 +9,7 @@
         var oblio_cui = $('#id_oblio_cui'),
             oblio_series_name = $('#id_oblio_series_name'),
             oblio_series_name_proforma = $('#id_oblio_series_name_proforma'),
+            oblio_series_name_notice = $('#id_oblio_series_name_notice'),
             oblio_workstation = $('#id_oblio_workstation'),
             oblio_management = $('#id_oblio_management'),
             useStock = parseInt(oblio_cui.find('option:selected').data('use-stock')) === 1;
@@ -30,6 +31,10 @@
             // series name proforma
             data.type = 'series_name_proforma';
             populateOptions(data, oblio_series_name_proforma);
+
+            // series name notice
+            data.type = 'series_name_notice';
+            populateOptions(data, oblio_series_name_notice);
             
             if (useStock) {
                 data.type = 'workstation';

--- a/view/settings_page.php
+++ b/view/settings_page.php
@@ -1,89 +1,90 @@
-
 <style type="text/css">
-.form-field select {width:95%;}
+    .form-field select {
+        width: 95%;
+    }
 </style>
 <script type="text/javascript">
-"use strict";
-(function($) {
-    $(document).ready(function() {
-        var oblio_cui = $('#id_oblio_cui'),
-            oblio_series_name = $('#id_oblio_series_name'),
-            oblio_series_name_proforma = $('#id_oblio_series_name_proforma'),
-            oblio_series_name_notice = $('#id_oblio_series_name_notice'),
-            oblio_workstation = $('#id_oblio_workstation'),
-            oblio_management = $('#id_oblio_management'),
-            useStock = parseInt(oblio_cui.find('option:selected').data('use-stock')) === 1;
-        
-        showManagement(useStock);
-        
-        oblio_cui.change(function() {
-            var self = $(this),
-                data = {
-                    action:'oblio',
-                    type:'series_name',
-                    cui:oblio_cui.val()
-                },
+    "use strict";
+    (function($) {
+        $(document).ready(function() {
+            var oblio_cui = $('#id_oblio_cui'),
+                oblio_series_name = $('#id_oblio_series_name'),
+                oblio_series_name_proforma = $('#id_oblio_series_name_proforma'),
+                oblio_series_name_notice = $('#id_oblio_series_name_notice'),
+                oblio_workstation = $('#id_oblio_workstation'),
+                oblio_management = $('#id_oblio_management'),
                 useStock = parseInt(oblio_cui.find('option:selected').data('use-stock')) === 1;
 
-            // series name
-            populateOptions(data, oblio_series_name);
-            
-            // series name proforma
-            data.type = 'series_name_proforma';
-            populateOptions(data, oblio_series_name_proforma);
-
-            // series name notice
-            data.type = 'series_name_notice';
-            populateOptions(data, oblio_series_name_notice);
-            
-            if (useStock) {
-                data.type = 'workstation';
-                populateOptions(data, oblio_workstation);
-                populateOptionsRender(oblio_management, [])
-            }
             showManagement(useStock);
-        });
-        oblio_workstation.change(function() {
-            var self = $(this),
-                data = {
-                    action:'oblio',
-                    type:'management',
-                    name:self.val(),
-                    cui:oblio_cui.val()
-                };
-            populateOptions(data, oblio_management);
-        });
-        
-        function showManagement(useStock) {
-            oblio_workstation.parent().parent().toggleClass('hidden', !useStock);
-            oblio_management.parent().parent().toggleClass('hidden', !useStock);
-        }
-        
-        function populateOptions(data, element, fn) {
-            jQuery.ajax({
-                type: 'post',
-                dataType: 'json',
-                url: ajaxurl,
-                data: data,
-                success: function(response) {
-                    populateOptionsRender(element, response, fn);
+
+            oblio_cui.change(function() {
+                var self = $(this),
+                    data = {
+                        action: 'oblio',
+                        type: 'series_name',
+                        cui: oblio_cui.val()
+                    },
+                    useStock = parseInt(oblio_cui.find('option:selected').data('use-stock')) === 1;
+
+                // series name
+                populateOptions(data, oblio_series_name);
+
+                // series name proforma
+                data.type = 'series_name_proforma';
+                populateOptions(data, oblio_series_name_proforma);
+
+                // series name notice
+                data.type = 'series_name_notice';
+                populateOptions(data, oblio_series_name_notice);
+
+                if (useStock) {
+                    data.type = 'workstation';
+                    populateOptions(data, oblio_workstation);
+                    populateOptionsRender(oblio_management, [])
                 }
+                showManagement(useStock);
             });
-        }
-        
-        function populateOptionsRender(element, data, fn) {
-            var options = '<option value="">Selecteaza</option>';
-            for (var index in data) {
-                var value = data[index];
-                options += '<option value="' + value.name + '">' + value.name + '</option>';
+            oblio_workstation.change(function() {
+                var self = $(this),
+                    data = {
+                        action: 'oblio',
+                        type: 'management',
+                        name: self.val(),
+                        cui: oblio_cui.val()
+                    };
+                populateOptions(data, oblio_management);
+            });
+
+            function showManagement(useStock) {
+                oblio_workstation.parent().parent().toggleClass('hidden', !useStock);
+                oblio_management.parent().parent().toggleClass('hidden', !useStock);
             }
-            element.html(options);
-            if (typeof fn === 'function') {
-                fn(data);
+
+            function populateOptions(data, element, fn) {
+                jQuery.ajax({
+                    type: 'post',
+                    dataType: 'json',
+                    url: ajaxurl,
+                    data: data,
+                    success: function(response) {
+                        populateOptionsRender(element, response, fn);
+                    }
+                });
             }
-        }
-    });
-})(jQuery);
+
+            function populateOptionsRender(element, data, fn) {
+                var options = '<option value="">Selecteaza</option>';
+                for (var index in data) {
+                    var value = data[index];
+                    options += '<option value="' + value.name + '">' + value.name + '</option>';
+                }
+                element.html(options);
+                if (typeof fn === 'function') {
+                    fn(data);
+                }
+            }
+        });
+    })(jQuery);
 </script>
 <div class="wrap woocommerce">
     <h1><?php esc_html_e('Setari Oblio', 'woocommerce-oblio'); ?></h1>
@@ -93,106 +94,111 @@
         <?php do_settings_sections('oblio-plugin-settings-group'); ?>
         <?php if ($error) echo sprintf('<div class="notice notice-error"><p>%s</p></div>', $error); ?>
         <table class="form-table">
-        <?php foreach ($fields as $field) { ?>
-            <tr valign="top" class="form-field">
-                <th scope="row"><?php echo esc_attr($field['label']); ?></th>
-                <td>
-                    <select name="<?php echo esc_attr($field['name']); ?>" id="id_<?php echo esc_attr($field['name']); ?>">
-                    <?php
-                        $selectedOption = get_option($field['name']);
-                        foreach ($field['options']['query'] as $option) {
-                            $isSelected = $option[$field['options']['id']] === $selectedOption;
-                            echo sprintf('<option value="%s"%s%s>%s</option>',
-                                $option[$field['options']['id']], $isSelected ? ' selected' : '',
-                                $showData($option, $field['options']['data'] ?? []),
-                                $option[$field['options']['name']]);
-                        }
-                    ?>
-                    </select>
-                </td>
-            </tr>
-        <?php } ?>
+            <?php foreach ($fields as $field) { ?>
+                <tr valign="top" class="form-field">
+                    <th scope="row"><?php echo esc_attr($field['label']); ?></th>
+                    <td>
+                        <select name="<?php echo esc_attr($field['name']); ?>" id="id_<?php echo esc_attr($field['name']); ?>">
+                            <?php
+                            $selectedOption = get_option($field['name']);
+                            foreach ($field['options']['query'] as $option) {
+                                $isSelected = $option[$field['options']['id']] === $selectedOption;
+                                echo sprintf(
+                                    '<option value="%s"%s%s>%s</option>',
+                                    $option[$field['options']['id']],
+                                    $isSelected ? ' selected' : '',
+                                    $showData($option, $field['options']['data'] ?? []),
+                                    $option[$field['options']['name']]
+                                );
+                            }
+                            ?>
+                        </select>
+                    </td>
+                </tr>
+            <?php } ?>
             <tr valign="top" class="form-field">
                 <th scope="row"><?php esc_html_e('Genereaza factura automat', 'woocommerce-oblio'); ?></th>
                 <td>
-                    <?php 
+                    <?php
                     $oblio_invoice_autogen = get_option('oblio_invoice_autogen');
                     ?>
-                    <input type="checkbox" name="oblio_invoice_autogen"<?php echo $oblio_invoice_autogen == '1' ? ' checked' : ''; ?> value="1" />
+                    <input type="checkbox" name="oblio_invoice_autogen" <?php echo $oblio_invoice_autogen == '1' ? ' checked' : ''; ?> value="1" />
                     <p class="description"><?php esc_html_e('Genereaza factura automat la schimbarea statusului comenzii in "Finalizat"', 'woocommerce-oblio'); ?></p>
                 </td>
             </tr>
             <tr valign="top" class="form-field">
                 <th scope="row"><?php esc_html_e('Descarcare de stoc la factura automata', 'woocommerce-oblio'); ?></th>
                 <td>
-                    <?php 
+                    <?php
                     $oblio_invoice_autogen_use_stock = get_option('oblio_invoice_autogen_use_stock');
                     ?>
-                    <input type="checkbox" name="oblio_invoice_autogen_use_stock"<?php echo $oblio_invoice_autogen_use_stock == '1' ? ' checked' : ''; ?> value="1" />
+                    <input type="checkbox" name="oblio_invoice_autogen_use_stock" <?php echo $oblio_invoice_autogen_use_stock == '1' ? ' checked' : ''; ?> value="1" />
                     <p class="description"><?php esc_html_e('Cand se genereaza factura automat produsele sunt descarcate din stoc', 'woocommerce-oblio'); ?></p>
                 </td>
             </tr>
             <tr valign="top" class="form-field">
                 <th scope="row"><?php esc_html_e('Genereaza proforma automat', 'woocommerce-oblio'); ?></th>
                 <td>
-                    <?php 
+                    <?php
                     $oblio_proforma_autogen = get_option('oblio_proforma_autogen');
                     ?>
-                    <input type="checkbox" name="oblio_proforma_autogen"<?php echo $oblio_proforma_autogen == '1' ? ' checked' : ''; ?> value="1" />
+                    <input type="checkbox" name="oblio_proforma_autogen" <?php echo $oblio_proforma_autogen == '1' ? ' checked' : ''; ?> value="1" />
                     <p class="description"><?php esc_html_e('Genereaza proforma automat la plasarea comenzii', 'woocommerce-oblio'); ?></p>
                 </td>
             </tr>
             <tr valign="top" class="form-field">
                 <th scope="row"><?php esc_html_e('Genereaza documente cu data', 'woocommerce-oblio'); ?></th>
                 <td>
-                    <?php 
+                    <?php
                     $oblio_gen_date = get_option('oblio_gen_date');
                     ?>
                     <select name="oblio_gen_date" id="id_oblio_gen_date">
-                      <option value="1"><?php esc_html_e('Emiterii', 'woocommerce-oblio'); ?></option>
-                      <option value="2"<?php echo $oblio_gen_date == '2' ? ' selected' : ''; ?>><?php esc_html_e('Comenzii', 'woocommerce-oblio'); ?></option>
+                        <option value="1"><?php esc_html_e('Emiterii', 'woocommerce-oblio'); ?></option>
+                        <option value="2" <?php echo $oblio_gen_date == '2' ? ' selected' : ''; ?>><?php esc_html_e('Comenzii', 'woocommerce-oblio'); ?></option>
                     </select>
                 </td>
             </tr>
             <tr valign="top" class="form-field">
                 <th scope="row"><?php esc_html_e('Incasare factura automata', 'woocommerce-oblio'); ?></th>
                 <td>
-                    <?php 
+                    <?php
                     $oblio_auto_collect = (int) get_option('oblio_auto_collect');
                     ?>
                     <select name="oblio_auto_collect" id="id_oblio_auto_collect">
-                      <option value="0"><?php esc_html_e('Nu', 'woocommerce-oblio'); ?></option>
-                      <option value="1"<?php echo $oblio_auto_collect === 1 ? ' selected' : ''; ?>><?php esc_html_e('Platile prin card', 'woocommerce-oblio'); ?></option>
-                      <option value="2"<?php echo $oblio_auto_collect === 2 ? ' selected' : ''; ?>><?php esc_html_e('Toate', 'woocommerce-oblio'); ?></option>
+                        <option value="0"><?php esc_html_e('Nu', 'woocommerce-oblio'); ?></option>
+                        <option value="1" <?php echo $oblio_auto_collect === 1 ? ' selected' : ''; ?>><?php esc_html_e('Platile prin card', 'woocommerce-oblio'); ?></option>
+                        <option value="2" <?php echo $oblio_auto_collect === 2 ? ' selected' : ''; ?>><?php esc_html_e('Toate', 'woocommerce-oblio'); ?></option>
                     </select>
                 </td>
             </tr>
             <tr valign="top" class="form-field">
                 <th scope="row"><?php esc_html_e('Seteaza ca finalizata comanda platita prin Card', 'woocommerce-oblio'); ?></th>
                 <td>
-                    <?php 
+                    <?php
                     $oblio_webhook_card_complete = get_option('oblio_webhook_card_complete');
                     ?>
-                    <input type="checkbox" name="oblio_webhook_card_complete"<?php echo intval($oblio_webhook_card_complete) === 1 ? ' checked' : ''; ?> value="1" />
+                    <input type="checkbox" name="oblio_webhook_card_complete" <?php echo intval($oblio_webhook_card_complete) === 1 ? ' checked' : ''; ?> value="1" />
                     <p class="description"><?php esc_html_e('Seteaza ca finalizata comanda platita prin integrarea cu cardul din Oblio (Link pe factura/proforma)', 'woocommerce-oblio'); ?></p>
                 </td>
             </tr>
             <tr valign="top" class="form-field">
-                <th colspan="2"><h2><?php esc_html_e('Email clienti', 'woocommerce-oblio'); ?></h2></th>
+                <th colspan="2">
+                    <h2><?php esc_html_e('Email clienti', 'woocommerce-oblio'); ?></h2>
+                </th>
             </tr>
             <tr valign="top" class="form-field">
                 <th scope="row"><?php esc_html_e('Trimite email la generare factura', 'woocommerce-oblio'); ?></th>
                 <td>
-                    <?php 
+                    <?php
                     $oblio_invoice_gen_send_email = get_option('oblio_invoice_gen_send_email');
                     ?>
-                    <input type="checkbox" name="oblio_invoice_gen_send_email"<?php echo $oblio_invoice_gen_send_email == '1' ? ' checked' : ''; ?> value="1" />
+                    <input type="checkbox" name="oblio_invoice_gen_send_email" <?php echo $oblio_invoice_gen_send_email == '1' ? ' checked' : ''; ?> value="1" />
                 </td>
             </tr>
             <tr valign="top" class="form-field">
                 <th scope="row"><?php esc_html_e('De la (optional)', 'woocommerce-oblio'); ?></th>
                 <td>
-                    <?php 
+                    <?php
                     $oblio_invoice_send_email_from = get_option('oblio_invoice_send_email_from');
                     ?>
                     <input type="text" name="oblio_invoice_send_email_from" value="<?php echo esc_attr($oblio_invoice_send_email_from); ?>" placeholder="nume@exemplu.ro" />
@@ -201,7 +207,7 @@
             <tr valign="top" class="form-field">
                 <th scope="row"><?php esc_html_e('Subiect email', 'woocommerce-oblio'); ?></th>
                 <td>
-                    <?php 
+                    <?php
                     $oblio_invoice_send_email_subject = get_option('oblio_invoice_send_email_subject', __('S-a emis [type] [serie] [numar]', 'woocommerce-oblio'));
                     ?>
                     <input type="text" name="oblio_invoice_send_email_subject" value="<?php echo esc_attr($oblio_invoice_send_email_subject); ?>" />
@@ -210,7 +216,7 @@
             <tr valign="top" class="form-field">
                 <th scope="row"><?php esc_html_e('CC', 'woocommerce-oblio'); ?></th>
                 <td>
-                    <?php 
+                    <?php
                     $oblio_invoice_send_email_cc = get_option('oblio_invoice_send_email_cc');
                     ?>
                     <input type="text" name="oblio_invoice_send_email_cc" value="<?php echo esc_attr($oblio_invoice_send_email_cc); ?>" />
@@ -218,19 +224,19 @@
             </tr>
             <tr valign="top" class="form-field">
                 <th scope="row">
-                  <?php esc_html_e('Mesaj email', 'woocommerce-oblio'); ?><br>
-                  <small>[type] = <?php esc_html_e('tip document', 'woocommerce-oblio'); ?></small><br>
-                  <small>[serie] = <?php esc_html_e('serie document', 'woocommerce-oblio'); ?></small><br>
-                  <small>[numar] = <?php esc_html_e('numar document', 'woocommerce-oblio'); ?></small><br>
-                  <small>[link] = <?php esc_html_e('link document', 'woocommerce-oblio'); ?></small><br>
-                  <small>[issue_date] = <?php esc_html_e('data emitere', 'woocommerce-oblio'); ?></small><br>
-                  <small>[due_date] = <?php esc_html_e('data scadenta', 'woocommerce-oblio'); ?></small><br>
-                  <small>[total] = <?php esc_html_e('total document', 'woocommerce-oblio'); ?></small><br>
-                  <small>[contact_name] = <?php esc_html_e('nume de contact', 'woocommerce-oblio'); ?></small><br>
-                  <small>[client_name] = <?php esc_html_e('nume de client', 'woocommerce-oblio'); ?></small><br>
+                    <?php esc_html_e('Mesaj email', 'woocommerce-oblio'); ?><br>
+                    <small>[type] = <?php esc_html_e('tip document', 'woocommerce-oblio'); ?></small><br>
+                    <small>[serie] = <?php esc_html_e('serie document', 'woocommerce-oblio'); ?></small><br>
+                    <small>[numar] = <?php esc_html_e('numar document', 'woocommerce-oblio'); ?></small><br>
+                    <small>[link] = <?php esc_html_e('link document', 'woocommerce-oblio'); ?></small><br>
+                    <small>[issue_date] = <?php esc_html_e('data emitere', 'woocommerce-oblio'); ?></small><br>
+                    <small>[due_date] = <?php esc_html_e('data scadenta', 'woocommerce-oblio'); ?></small><br>
+                    <small>[total] = <?php esc_html_e('total document', 'woocommerce-oblio'); ?></small><br>
+                    <small>[contact_name] = <?php esc_html_e('nume de contact', 'woocommerce-oblio'); ?></small><br>
+                    <small>[client_name] = <?php esc_html_e('nume de client', 'woocommerce-oblio'); ?></small><br>
                 </th>
                 <td>
-                    <?php 
+                    <?php
                     $oblio_invoice_send_email_message = get_option('oblio_invoice_send_email_message', __("Buna ziua,
 
 Va informam ca am emis [type] [serie] [numar] .
@@ -246,25 +252,27 @@ Va multumim.", 'woocommerce-oblio'));
                 </td>
             </tr>
             <tr valign="top" class="form-field">
-                <th colspan="2"><h2><?php esc_html_e('Sincronizare', 'woocommerce-oblio'); ?></h2></th>
+                <th colspan="2">
+                    <h2><?php esc_html_e('Sincronizare', 'woocommerce-oblio'); ?></h2>
+                </th>
             </tr>
             <tr valign="top" class="form-field">
                 <th scope="row"><?php esc_html_e('Sincronizare automata cu stocul Oblio', 'woocommerce-oblio'); ?></th>
                 <td>
-                    <?php 
+                    <?php
                     $oblio_stock_sync = (int) get_option('oblio_stock_sync');
                     ?>
-                    <input type="checkbox" name="oblio_stock_sync"<?php echo $oblio_stock_sync === 1 ? ' checked' : ''; ?> value="1" />
+                    <input type="checkbox" name="oblio_stock_sync" <?php echo $oblio_stock_sync === 1 ? ' checked' : ''; ?> value="1" />
                     <p class="description"><?php esc_html_e('Codul produsului din Oblio trebuie sa fie acelasi cu codul produsului din site-ul dvs.', 'woocommerce-oblio'); ?></p>
                 </td>
             </tr>
             <tr valign="top" class="form-field">
                 <th scope="row"><?php esc_html_e('Rezerva stoc comenzi', 'woocommerce-oblio'); ?></th>
                 <td>
-                    <?php 
+                    <?php
                     $oblio_stock_adjusments = (int) get_option('oblio_stock_adjusments');
                     ?>
-                    <input type="checkbox" name="oblio_stock_adjusments"<?php echo $oblio_stock_adjusments === 1 ? ' checked' : ''; ?> value="1" />
+                    <input type="checkbox" name="oblio_stock_adjusments" <?php echo $oblio_stock_adjusments === 1 ? ' checked' : ''; ?> value="1" />
                     <p class="description">
                         <?php _e('Stocul din magazin va fi stocul din Oblio minus comenzile din ultimele 30 de zile cu status "Plata in asteptare", "In asteptare" sau "In procesare". <br>
                         Practic fara comenzile Nefacturate', 'woocommerce-oblio'); ?>
@@ -272,16 +280,18 @@ Va multumim.", 'woocommerce-oblio'));
                 </td>
             </tr>
             <tr valign="top" class="form-field">
-                <th colspan="2"><h2><?php esc_html_e('Optiuni factura', 'woocommerce-oblio'); ?></h2></th>
+                <th colspan="2">
+                    <h2><?php esc_html_e('Optiuni factura', 'woocommerce-oblio'); ?></h2>
+                </th>
             </tr>
             <tr valign="top" class="form-field">
                 <th scope="row"><?php esc_html_e('Limba', 'woocommerce-oblio'); ?></th>
                 <td>
-                    <?php 
+                    <?php
                     $oblio_invoice_language = get_option('oblio_invoice_language');
                     echo '<select name="oblio_invoice_language">';
                     $languages = _wp_oblio_get_languages();
-                    foreach ($languages as $lang_code=>$language) {
+                    foreach ($languages as $lang_code => $language) {
                         echo sprintf('<option value="%1$s"%3$s>%2$s</option>', $lang_code, $language, $lang_code === $oblio_invoice_language ? ' selected' : '');
                     }
                     echo '</select>';
@@ -291,7 +301,7 @@ Va multumim.", 'woocommerce-oblio'));
             <tr valign="top" class="form-field">
                 <th scope="row"><?php esc_html_e('Unitate de masura', 'woocommerce-oblio'); ?></th>
                 <td>
-                    <?php 
+                    <?php
                     $oblio_invoice_measuring_unit = get_option('oblio_invoice_measuring_unit', 'buc');
                     ?>
                     <input type="text" name="oblio_invoice_measuring_unit" value="<?php echo esc_attr($oblio_invoice_measuring_unit); ?>" />
@@ -300,7 +310,7 @@ Va multumim.", 'woocommerce-oblio'));
             <tr valign="top" class="form-field">
                 <th scope="row"><?php esc_html_e('Unitate de masura tradusa', 'woocommerce-oblio'); ?></th>
                 <td>
-                    <?php 
+                    <?php
                     $oblio_invoice_measuring_unit_translation = get_option('oblio_invoice_measuring_unit_translation', '');
                     ?>
                     <input type="text" name="oblio_invoice_measuring_unit_translation" value="<?php echo esc_attr($oblio_invoice_measuring_unit_translation); ?>" />
@@ -309,7 +319,7 @@ Va multumim.", 'woocommerce-oblio'));
             <tr valign="top" class="form-field">
                 <th scope="row"><?php esc_html_e('Tip produs', 'woocommerce-oblio'); ?></th>
                 <td>
-                    <?php 
+                    <?php
                     $oblio_product_type = get_option('oblio_product_type');
                     echo '<select name="oblio_product_type">';
                     $product_types = _wp_oblio_get_products_type();
@@ -323,7 +333,7 @@ Va multumim.", 'woocommerce-oblio'));
             <tr valign="top" class="form-field">
                 <th scope="row"><?php esc_html_e('Scadenta', 'woocommerce-oblio'); ?></th>
                 <td>
-                    <?php 
+                    <?php
                     $oblio_invoice_due = get_option('oblio_invoice_due');
                     ?>
                     <input type="text" placeholder="Introdu numarul de zile de scadenta" name="oblio_invoice_due" value="<?php echo esc_attr($oblio_invoice_due); ?>" />
@@ -332,7 +342,7 @@ Va multumim.", 'woocommerce-oblio'));
             <tr valign="top" class="form-field">
                 <th scope="row"><?php esc_html_e('Intocmit de', 'woocommerce-oblio'); ?></th>
                 <td>
-                    <?php 
+                    <?php
                     $oblio_invoice_issuer_name = get_option('oblio_invoice_issuer_name');
                     ?>
                     <input type="text" name="oblio_invoice_issuer_name" value="<?php echo esc_attr($oblio_invoice_issuer_name); ?>" />
@@ -341,7 +351,7 @@ Va multumim.", 'woocommerce-oblio'));
             <tr valign="top" class="form-field">
                 <th scope="row"><?php esc_html_e('CNP', 'woocommerce-oblio'); ?></th>
                 <td>
-                    <?php 
+                    <?php
                     $oblio_invoice_issuer_id = get_option('oblio_invoice_issuer_id');
                     ?>
                     <input type="text" name="oblio_invoice_issuer_id" value="<?php echo esc_attr($oblio_invoice_issuer_id); ?>" />
@@ -350,7 +360,7 @@ Va multumim.", 'woocommerce-oblio'));
             <tr valign="top" class="form-field">
                 <th scope="row"><?php esc_html_e('Delegat', 'woocommerce-oblio'); ?></th>
                 <td>
-                    <?php 
+                    <?php
                     $oblio_invoice_deputy_name = get_option('oblio_invoice_deputy_name');
                     ?>
                     <input type="text" name="oblio_invoice_deputy_name" value="<?php echo esc_attr($oblio_invoice_deputy_name); ?>" />
@@ -359,7 +369,7 @@ Va multumim.", 'woocommerce-oblio'));
             <tr valign="top" class="form-field">
                 <th scope="row"><?php esc_html_e('Carte Identitate', 'woocommerce-oblio'); ?></th>
                 <td>
-                    <?php 
+                    <?php
                     $oblio_invoice_deputy_identity_card = get_option('oblio_invoice_deputy_identity_card');
                     ?>
                     <input type="text" name="oblio_invoice_deputy_identity_card" value="<?php echo esc_attr($oblio_invoice_deputy_identity_card); ?>" />
@@ -368,7 +378,7 @@ Va multumim.", 'woocommerce-oblio'));
             <tr valign="top" class="form-field">
                 <th scope="row"><?php esc_html_e('Auto', 'woocommerce-oblio'); ?></th>
                 <td>
-                    <?php 
+                    <?php
                     $oblio_invoice_deputy_auto = get_option('oblio_invoice_deputy_auto');
                     ?>
                     <input type="text" name="oblio_invoice_deputy_auto" value="<?php echo esc_attr($oblio_invoice_deputy_auto); ?>" />
@@ -377,7 +387,7 @@ Va multumim.", 'woocommerce-oblio'));
             <tr valign="top" class="form-field">
                 <th scope="row"><?php esc_html_e('Agent vanzari', 'woocommerce-oblio'); ?></th>
                 <td>
-                    <?php 
+                    <?php
                     $oblio_invoice_seles_agent = get_option('oblio_invoice_seles_agent');
                     ?>
                     <input type="text" name="oblio_invoice_seles_agent" value="<?php echo esc_attr($oblio_invoice_seles_agent); ?>" />
@@ -385,14 +395,14 @@ Va multumim.", 'woocommerce-oblio'));
             </tr>
             <tr valign="top" class="form-field">
                 <th scope="row">
-                  <?php esc_html_e('Mentiuni', 'woocommerce-oblio'); ?><br>
-                  <small>[order_id] = <?php esc_html_e('numar comanda', 'woocommerce-oblio'); ?></small><br>
-                  <small>[date] = <?php esc_html_e('data comanda', 'woocommerce-oblio'); ?></small><br>
-                  <small>[payment] = <?php esc_html_e('modalitate de plata', 'woocommerce-oblio'); ?></small><br>
+                    <?php esc_html_e('Mentiuni', 'woocommerce-oblio'); ?><br>
+                    <small>[order_id] = <?php esc_html_e('numar comanda', 'woocommerce-oblio'); ?></small><br>
+                    <small>[date] = <?php esc_html_e('data comanda', 'woocommerce-oblio'); ?></small><br>
+                    <small>[payment] = <?php esc_html_e('modalitate de plata', 'woocommerce-oblio'); ?></small><br>
                     <small>[shipping] = <?php esc_html_e('modalitate de livrare', 'woocommerce-oblio'); ?></small><br>
                 </th>
                 <td>
-                    <?php 
+                    <?php
                     $oblio_invoice_mentions = get_option('oblio_invoice_mentions');
                     ?>
                     <textarea rows="7" name="oblio_invoice_mentions"><?php echo esc_attr($oblio_invoice_mentions); ?></textarea>
@@ -401,54 +411,54 @@ Va multumim.", 'woocommerce-oblio'));
             <tr valign="top" class="form-field">
                 <th scope="row"><?php esc_html_e('Include discountul in pretul produsului', 'woocommerce-oblio'); ?></th>
                 <td>
-                    <?php 
+                    <?php
                     $oblio_invoice_discount_in_product = get_option('oblio_invoice_discount_in_product');
                     ?>
-                    <input type="checkbox" name="oblio_invoice_discount_in_product"<?php echo $oblio_invoice_discount_in_product == '1' ? ' checked' : ''; ?> value="1" />
+                    <input type="checkbox" name="oblio_invoice_discount_in_product" <?php echo $oblio_invoice_discount_in_product == '1' ? ' checked' : ''; ?> value="1" />
                 </td>
             </tr>
             <tr valign="top" class="form-field">
                 <th scope="row"><?php esc_html_e('Ascunde detalii produs', 'woocommerce-oblio'); ?></th>
                 <td>
-                    <?php 
+                    <?php
                     $oblio_hide_description = get_option('oblio_hide_description');
                     ?>
-                     <input type="checkbox" name="oblio_hide_description"<?php echo $oblio_hide_description == '1' ? ' checked' : ''; ?> value="1" />
+                    <input type="checkbox" name="oblio_hide_description" <?php echo $oblio_hide_description == '1' ? ' checked' : ''; ?> value="1" />
                     <p class="description"><?php esc_html_e('Optiune in cazul in care doriti sa ascundeti detaliile', 'woocommerce-oblio'); ?></p>
                 </td>
             </tr>
             <tr valign="top" class="form-field">
                 <th scope="row"><?php esc_html_e('Completeaza automat datele pentru companii', 'woocommerce-oblio'); ?></th>
                 <td>
-                    <?php 
+                    <?php
                     $oblio_autocomplete_company = get_option('oblio_autocomplete_company');
                     ?>
-                     <input type="checkbox" name="oblio_autocomplete_company"<?php echo $oblio_autocomplete_company == '1' ? ' checked' : ''; ?> value="1" />
+                    <input type="checkbox" name="oblio_autocomplete_company" <?php echo $oblio_autocomplete_company == '1' ? ' checked' : ''; ?> value="1" />
                     <p class="description"><?php esc_html_e('Completeaza automat datele pentru companiile din Romania pe baza CIF-ului', 'woocommerce-oblio'); ?></p>
                 </td>
             </tr>
             <tr valign="top" class="form-field">
                 <th scope="row"><?php esc_html_e('Dezactiveaza modifcarea pretul produsului in Oblio', 'woocommerce-oblio'); ?></th>
                 <td>
-                    <?php 
+                    <?php
                     $oblio_notsave_price = get_option('oblio_notsave_price');
                     ?>
-                     <input type="checkbox" name="oblio_notsave_price"<?php echo $oblio_notsave_price == '1' ? ' checked' : ''; ?> value="1" />
+                    <input type="checkbox" name="oblio_notsave_price" <?php echo $oblio_notsave_price == '1' ? ' checked' : ''; ?> value="1" />
                     <p class="description"><?php esc_html_e('Dezactiveaza modifcarea pretul produsului in Oblio la generearea facturii', 'woocommerce-oblio'); ?></p>
                 </td>
             </tr>
             <tr valign="top" class="form-field">
                 <th scope="row"><?php esc_html_e('Activeaza actualizarea pretului produsului in WooCommerce in momentul sincronizarii stocului', 'woocommerce-oblio'); ?></th>
                 <td>
-                    <?php 
+                    <?php
                     $oblio_update_price = get_option('oblio_update_price');
                     ?>
-                     <input type="checkbox" name="oblio_update_price"<?php echo $oblio_update_price == '1' ? ' checked' : ''; ?> value="1" />
+                    <input type="checkbox" name="oblio_update_price" <?php echo $oblio_update_price == '1' ? ' checked' : ''; ?> value="1" />
                     <p class="description"><?php esc_html_e('La sincronizarea stocului, preturile de vanzare ale produselor vor fi actualizate conform valorilor listate in Oblio', 'woocommerce-oblio'); ?></p>
                 </td>
             </tr>
         </table>
-        
+
         <?php submit_button(); ?>
 
     </form>

--- a/woocommerce-oblio.php
+++ b/woocommerce-oblio.php
@@ -179,6 +179,7 @@ function _wp_oblio_generate_invoice($order_id, $options = array()) {
     }
     switch ($options['docType']) {
         case 'proforma': $series_name = get_option('oblio_series_name_proforma'); break;
+        case 'notice': $series_name = get_option('oblio_series_name_notice'); break;
         default: $series_name = get_option('oblio_series_name');
     }
     $series_name_key = 'oblio_' . $options['docType'] . '_series_name';
@@ -217,6 +218,7 @@ function _wp_oblio_generate_invoice($order_id, $options = array()) {
     if (empty($use_stock)) {
         $options['use_stock'] = 0;
     }
+    
     if (!empty($options['date'])) {
         $issueDate = $options['date'];
     } else {
@@ -296,7 +298,6 @@ function _wp_oblio_generate_invoice($order_id, $options = array()) {
         'products'           => [],
         'issuerName'         => get_option('oblio_invoice_issuer_name'),
         'issuerId'           => get_option('oblio_invoice_issuer_id'),
-        'noticeNumber'       => '',
         'internalNote'       => '',
         'deputyName'         => get_option('oblio_invoice_deputy_name'),
         'deputyIdentityCard' => get_option('oblio_invoice_deputy_identity_card'),
@@ -307,6 +308,11 @@ function _wp_oblio_generate_invoice($order_id, $options = array()) {
         'workStation'        => $workstation,
         'useStock'           => empty($options['use_stock']) ? 0 : 1,
     );
+
+    // Oblio API docs: notices don't support the "noticeNumber" parameter.
+    if ($options['docType'] !== 'notice') {
+        $data['noticeNumber'] = '';
+    }
     
     if (empty($data['referenceDocument'])) {
         /** @var \WC_Order_Item_Product[] */
@@ -508,6 +514,7 @@ function _wp_oblio_generate_invoice($order_id, $options = array()) {
         $api = new OblioSoftware\Api($email, $secret, $accessTokenHandler);
         switch ($options['docType']) {
             case 'proforma': $result = $api->createProforma($data); break;
+            case 'notice': $result = $api->createNotice($data); break;
             default: $result = $api->createInvoice($data);
         }
 

--- a/woocommerce-oblio.php
+++ b/woocommerce-oblio.php
@@ -240,13 +240,6 @@ function _wp_oblio_generate_invoice($order_id, $options = array()) {
 
 
     $collect = [];
-    $isCard = !in_array($order->get_payment_method(), ['bacs', 'cod']);
-    if ($options['docType'] === 'proforma' && $isCard) {
-        return [
-            'error' => 'Nu se pot genera proforme pentru comanzile incasate prin card'
-        ];
-    }
-
     if ($auto_collect !== 0) {
         if (($auto_collect === 1 && $isCard) || $auto_collect === 2) {
             $type = 'Card';

--- a/woocommerce-oblio.php
+++ b/woocommerce-oblio.php
@@ -20,6 +20,8 @@ defined('ABSPATH') || exit;
 
 include WP_OBLIO_DIR . '/includes/Hooks.php';
 include WP_OBLIO_DIR . '/src/Autoloader.php';
+include WP_OBLIO_DIR . '/includes/class-oblio-autocomplete.php';
+
 
 OblioSoftware\Autoloader::init(WP_OBLIO_DIR . '/src');
 
@@ -266,6 +268,14 @@ function _wp_oblio_generate_invoice($order_id, $options = array()) {
     if ($state === 'București' && preg_match('/^S\s*([1-6])$/', $city, $matches)) {
 		$city = 'SECTOR ' . $matches[1];
     };
+
+    // Optional per-document overrides (sent from order edit UI).
+    $issuerName = !empty($options['issuerName']) ? $options['issuerName'] : get_option('oblio_invoice_issuer_name');
+    $issuerId = !empty($options['issuerId']) ? $options['issuerId'] : get_option('oblio_invoice_issuer_id');
+    $deputyName = !empty($options['deputyName']) ? $options['deputyName'] : get_option('oblio_invoice_deputy_name');
+    $deputyIdentityCard = !empty($options['deputyIdentityCard']) ? $options['deputyIdentityCard'] : get_option('oblio_invoice_deputy_identity_card');
+    $deputyAuto = !empty($options['deputyAuto']) ? $options['deputyAuto'] : get_option('oblio_invoice_deputy_auto');
+
     $data = array(
         'cif'                => $cui,
         'client'             => [
@@ -296,12 +306,12 @@ function _wp_oblio_generate_invoice($order_id, $options = array()) {
         'precision'          => get_option('woocommerce_price_num_decimals', 2),
         'currency'           => $currency,
         'products'           => [],
-        'issuerName'         => get_option('oblio_invoice_issuer_name'),
-        'issuerId'           => get_option('oblio_invoice_issuer_id'),
+        'issuerName'         => $issuerName,
+        'issuerId'           => $issuerId,
         'internalNote'       => '',
-        'deputyName'         => get_option('oblio_invoice_deputy_name'),
-        'deputyIdentityCard' => get_option('oblio_invoice_deputy_identity_card'),
-        'deputyAuto'         => get_option('oblio_invoice_deputy_auto'),
+        'deputyName'         => $deputyName,
+        'deputyIdentityCard' => $deputyIdentityCard,
+        'deputyAuto'         => $deputyAuto,
         'selesAgent'         => get_option('oblio_invoice_seles_agent'),
         'mentions'           => $oblio_invoice_mentions,
         'value'              => 0,
@@ -310,8 +320,11 @@ function _wp_oblio_generate_invoice($order_id, $options = array()) {
     );
 
     // Oblio API docs: notices don't support the "noticeNumber" parameter.
+    // For invoices/proformas we include the existing Notice number (if a notice was already issued for this order).
     if ($options['docType'] !== 'notice') {
-        $data['noticeNumber'] = '';
+        $existingNoticeNumber = trim((string) $order->get_data_info('oblio_notice_number'));
+        $existingNoticeSeriesName = trim((string) $order->get_data_info('oblio_notice_series_name'));
+        $data['noticeNumber'] = $existingNoticeNumber !== '' ? $existingNoticeSeriesName . $existingNoticeNumber : '';
     }
     
     if (empty($data['referenceDocument'])) {


### PR DESCRIPTION
Am adaugat butoanele de emite si sterge aviz intrucat lipsesc.
In momentul de fata trebuie intai sa emit proforma si din proforma sa merg apoi in oblio ca sa emit aviz, ceea ce e ineficient.
Implementarea mea are totusi un mic "bug" cred, in sensul ca atunci cand incerci sa generezi a 2-a oara avizul de transport (dupa ce l-ai sters pe primul) din WooCommerce, apare popup-ul verde cu "Avizul a fost emis...", dar in Oblio nu apare avizul. Prima data cand emit avizul pentru o comanda, totul merge ok.

Totodata, cand incercam sa emit proforme, pe modelul vechi pentru comenzile create de mine in WooCommerce admin, imi dadea eroarea cu "Nu se pot genera proforme pentru comanzile incasate prin card", ceea ce nu era corect, pentru ca nu selectasem niciunde metoda de plata ca fiind cu cardul (nici nu exista aceasta optiune in setarile mele de WooCommerce) si ma incurca.
<img width="290" height="392" alt="Facturare Oblio" src="https://github.com/user-attachments/assets/ba7259ce-9ebf-498b-8065-7b4b81cc2989" />
<img width="1551" height="417" alt="Setari WooCommerce Plati" src="https://github.com/user-attachments/assets/f47151d8-da1d-4858-854a-733e8d082acc" />
<img width="1528" height="496" alt="Setari WooCommerce Plati 2" src="https://github.com/user-attachments/assets/b180efa2-7d90-4808-8e5f-cc2ef5252b33" />

Este mai mult facut on the fly, deci spuneti-mi ce nu e bine si incerc sa modific.