### PR TITLE
Storno (refund)

### DIFF
--- a/includes/Hooks.php
+++ b/includes/Hooks.php
@@ -152,6 +152,7 @@ function _wp_oblio_invoice_ajax_handler() {
         case 'oblio-view-proforma': die(_wp_oblio_generate_invoice($order_id, ['redirect' => true, 'docType' => 'proforma', 'date' => $date])); break; 
         case 'oblio-delete-invoice': $result = _wp_oblio_delete_invoice($order_id); break;
         case 'oblio-delete-proforma': $result = _wp_oblio_delete_invoice($order_id, ['docType' => 'proforma']); break;
+	    case 'oblio-storno-invoice': $result = _wp_oblio_storno_invoice($order_id); break;
     }
     die(json_encode($result));
 }

--- a/view/components/order_details_invoice_box.php
+++ b/view/components/order_details_invoice_box.php
@@ -95,6 +95,29 @@ $displayDocument = function ( $post, $options = [] ) use ( $wpdb, $order ) {
 		);
 	}
 
+    if ( $options['docType'] === 'invoice' ) {
+        $storno_series = $order->get_data_info( 'oblio_storno_series_name' );
+        $storno_number = $order->get_data_info( 'oblio_storno_number' );
+        $storno_link   = $order->get_data_info( 'oblio_storno_link' );
+        $hasStorno     = $storno_series && $storno_number && $storno_link;
+        $stornoBtnHide = ( $link && ! $hasStorno ) ? '' : 'hidden';
+        echo sprintf(
+                '<p><a class="button oblio-storno-%s %s" style="background:#c9356e;border-color:#a82a59;color:#fff;text-shadow:none;box-shadow:none;" href="%s" target="_blank">%s</a></p>',
+                $options['docType'],
+                $stornoBtnHide,
+                _wp_oblio_build_url( 'oblio-storno-' . $options['docType'], $post ),
+                __( 'Stornează factura', 'woocommerce-oblio' )
+        );
+        if ( $hasStorno ) {
+            echo sprintf(
+                    '<p><a class="button" href="%s" target="_blank">%s</a></p>',
+                    esc_url( $storno_link ),
+                    sprintf( __( 'Vezi factura storno %s %d', 'woocommerce-oblio' ), $storno_series, (int) $storno_number )
+            );
+        }
+    }
+
+
 	if ( isset( $options['fn'] ) && is_callable( $options['fn'] ) ) {
 		$options['fn']( [
 			'series_name' => $series_name,
@@ -172,6 +195,34 @@ $displayDocument = function ( $post, $options = [] ) use ( $wpdb, $order ) {
                         }
                     });
                 });
+                <?php if ( $options['docType'] === 'invoice' ) { ?>
+                var stornoButton = $('.oblio-storno-<?php echo $options['docType']; ?>');
+                stornoButton.on('click', function (e) {
+                    e.preventDefault();
+                    var self = $(this);
+                    if (self.hasClass('disabled')) {
+                        return false;
+                    }
+                    if (!window.confirm('Esti sigur ca vrei sa emiti factura storno (refund 100%)? Aceasta actiune nu poate fi anulata.')) {
+                        return false;
+                    }
+                    self.addClass('disabled');
+                    jQuery.ajax({
+                        dataType: 'json',
+                        url: self.attr('href'),
+                        data: {},
+                        success: function (response) {
+                            if (response.type == 'success') {
+                                location.reload();
+                            } else {
+                                var alert = '<ul class="order_notes"><li class="note system-note"><div class="note_content note_error">' + response.message + '</div></li></ul>';
+                                responseContainer.html(alert);
+                                self.removeClass('disabled');
+                            }
+                        }
+                    });
+                });
+                <?php } ?>
             });
         })(jQuery);
     </script>

--- a/woocommerce-oblio.php
+++ b/woocommerce-oblio.php
@@ -147,6 +147,98 @@ function _wp_oblio_delete_invoice($order_id, $options = []) {
     return $result;
 }
 
+function _wp_oblio_storno_invoice($order_id, $options = []) {
+    $order_id = (int) $order_id;
+    if (!$order_id) {
+        return array();
+    }
+
+    $email       = get_option('oblio_email');
+    $secret      = get_option('oblio_api_secret');
+    $cui         = get_option('oblio_cui');
+    $series_cfg  = get_option('oblio_series_name');
+    $result      = array(
+            'type'    => 'error',
+            'message' => '',
+    );
+
+    $series_name = $options['series_name'] ?? '';
+    $number      = $options['number'] ?? '';
+
+    $order = new OblioSoftware\Order($order_id);
+    if (!$series_name) {
+        $series_name = $order->get_data_info('oblio_invoice_series_name');
+    }
+    if (!$number) {
+        $number = $order->get_data_info('oblio_invoice_number');
+    }
+    $link = $order->get_data_info('oblio_invoice_link');
+
+    if (!$link || !$series_name || !$number) {
+        $result['message'] = 'Nu exista factura de stornat';
+        return $result;
+    }
+    if ($order->get_data_info('oblio_storno_link')) {
+        $result['message'] = 'Factura este deja stornata';
+        return $result;
+    }
+    if (!$email || !$secret || !$cui || !$series_cfg) {
+        $result['message'] = 'Eroare configurare, intra la Oblio &gt; Setari';
+        return $result;
+    }
+
+    $data = [
+            'cif'               => $cui,
+            'seriesName'        => $series_cfg,
+            'issueDate'         => date('Y-m-d'),
+            'idempotencyKey'    => _wp_oblio_idempotence_key($order_id) . '-storno',
+            'referenceDocument' => [
+                    'type'       => 'Factura',
+                    'refund'     => 1,
+                    'seriesName' => $series_name,
+                    'number'     => (int) $number,
+            ],
+    ];
+
+    try {
+        $accessTokenHandler = new OblioSoftware\Api\AccessTokenHandler();
+        $api = new OblioSoftware\Api($email, $secret, $accessTokenHandler);
+        $response = $api->createInvoice($data);
+
+        if (isset($response['status']) && (int) $response['status'] === 200) {
+            try {
+                wc_transaction_query('start');
+
+                $order->set_data_info('oblio_storno_series_name', $response['data']['seriesName']);
+                $order->set_data_info('oblio_storno_number', $response['data']['number']);
+                $order->set_data_info('oblio_storno_link', $response['data']['link']);
+                $order->set_data_info('oblio_storno_date', date('Y-m-d'));
+                $order->save();
+
+                wc_transaction_query('commit');
+            } catch (Exception $e) {
+                wc_transaction_query('rollback');
+            }
+
+            $result['type']       = 'success';
+            $result['message']    = sprintf('Factura storno %s %s a fost emisa', $response['data']['seriesName'], $response['data']['number']);
+            $result['seriesName'] = $response['data']['seriesName'];
+            $result['number']     = $response['data']['number'];
+            $result['link']       = $response['data']['link'];
+        } else {
+            $result['message'] = $response['statusMessage'] ?? 'Eroare la stornare';
+        }
+    } catch (Exception $e) {
+        $message = $e->getMessage();
+        if ($message === 'The access token provided is invalid' && isset($accessTokenHandler)) {
+            $accessTokenHandler->clear();
+        }
+        $result['message'] = $message;
+    }
+    return $result;
+}
+
+
 function _wp_oblio_build_url($action, $post) {
     return get_site_url(null, 'wp-admin/admin-ajax.php?action=oblio_invoice&a=' . $action . '&id=' .
         (method_exists($post, 'get_id') ? $post->get_id() : $post->ID));


### PR DESCRIPTION
add 100% storno (refund) invoice action to order side box

  Adds a red "Storneaza factura" button to the Oblio order_details_invoice_box
  meta box. Clicking it issues a full-refund storno invoice via the Oblio API
  and stores the resulting document on the WC order.

  - woocommerce-oblio.php: new _wp_oblio_storno_invoice() that POSTs to /api/docs/invoice with referenceDocument.refund=1 and the original seriesName/number. The new storno doc is saved to oblio_storno_series_name, oblio_storno_number, oblio_storno_link and oblio_storno_date (wrapped in wc_transaction_query). Original oblio_invoice_* meta is left untouched so both documents remain visible. Idempotency key uses the order key with a "-storno" suffix.
  - includes/Hooks.php: route the new "oblio-storno-invoice" AJAX action through the existing _wp_oblio_invoice_ajax_handler.
  - view/components/order_details_invoice_box.php: render the red button only for docType=invoice when an invoice exists and no storno is recorded yet; after success the page reloads and the button is replaced with a "Vezi factura storno SERIE NR" link to the storno PDF. JS handler shows a window.confirm() prompt before firing and surfaces API errors in the existing .oblio-ajax-response slot.

  Notes:
  - Uses the configured oblio_series_name option for the new storno's own series.
  - AJAX handler has no nonce/capability check (matches the existing generate/delete actions);
  - Does not create a WooCommerce refund or touch the payment gateway -- **fiscal-document only.**